### PR TITLE
Issue #1: add support of default attribute values

### DIFF
--- a/cz.zcu.yafmt.clang.bcl/plugin.properties
+++ b/cz.zcu.yafmt.clang.bcl/plugin.properties
@@ -1,0 +1,4 @@
+#
+
+pluginName = BooleanConstraintLanguage Model
+providerName = www.example.org

--- a/cz.zcu.yafmt.clang.bcl/plugin.xml
+++ b/cz.zcu.yafmt.clang.bcl/plugin.xml
@@ -7,7 +7,7 @@
     <package 
        uri = "http://zcu.cz/yafmt/clang/bcl" 
        class = "cz.zcu.yafmt.clang.bcl.model.ModelPackage"
-       genModel = "cz/zcu/yafmt/clang/bcl/BooleanConstraintLanguage.genmodel" /> 
+       genModel = "model/BooleanConstraintLanguage.genmodel" /> 
 	
   </extension>
   <extension

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Conjunction.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Conjunction.java
@@ -10,11 +10,11 @@ package cz.zcu.yafmt.clang.bcl.model;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getLeftPart <em>Left Part</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getRightPart <em>Right Part</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getConjunction()
  * @model
@@ -22,55 +22,55 @@ package cz.zcu.yafmt.clang.bcl.model;
  */
 public interface Conjunction extends Expression {
     /**
-     * Returns the value of the '<em><b>Left Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Left Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Left Part</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Left Part</em>' containment reference.
-     * @see #setLeftPart(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getConjunction_LeftPart()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Left Part</em>' containment reference.
+	 * @see #setLeftPart(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getConjunction_LeftPart()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getLeftPart();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getLeftPart <em>Left Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getLeftPart <em>Left Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Left Part</em>' containment reference.
-     * @see #getLeftPart()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Left Part</em>' containment reference.
+	 * @see #getLeftPart()
+	 * @generated
+	 */
     void setLeftPart(Expression value);
 
     /**
-     * Returns the value of the '<em><b>Right Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Right Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Right Part</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Right Part</em>' containment reference.
-     * @see #setRightPart(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getConjunction_RightPart()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Right Part</em>' containment reference.
+	 * @see #setRightPart(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getConjunction_RightPart()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getRightPart();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getRightPart <em>Right Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getRightPart <em>Right Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Right Part</em>' containment reference.
-     * @see #getRightPart()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Right Part</em>' containment reference.
+	 * @see #getRightPart()
+	 * @generated
+	 */
     void setRightPart(Expression value);
 
 } // Conjunction

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Disjunction.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Disjunction.java
@@ -10,11 +10,11 @@ package cz.zcu.yafmt.clang.bcl.model;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getLeftPart <em>Left Part</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getRightPart <em>Right Part</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getDisjunction()
  * @model
@@ -22,55 +22,55 @@ package cz.zcu.yafmt.clang.bcl.model;
  */
 public interface Disjunction extends Expression {
     /**
-     * Returns the value of the '<em><b>Left Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Left Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Left Part</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Left Part</em>' containment reference.
-     * @see #setLeftPart(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getDisjunction_LeftPart()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Left Part</em>' containment reference.
+	 * @see #setLeftPart(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getDisjunction_LeftPart()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getLeftPart();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getLeftPart <em>Left Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getLeftPart <em>Left Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Left Part</em>' containment reference.
-     * @see #getLeftPart()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Left Part</em>' containment reference.
+	 * @see #getLeftPart()
+	 * @generated
+	 */
     void setLeftPart(Expression value);
 
     /**
-     * Returns the value of the '<em><b>Right Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Right Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Right Part</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Right Part</em>' containment reference.
-     * @see #setRightPart(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getDisjunction_RightPart()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Right Part</em>' containment reference.
+	 * @see #setRightPart(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getDisjunction_RightPart()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getRightPart();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getRightPart <em>Right Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getRightPart <em>Right Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Right Part</em>' containment reference.
-     * @see #getRightPart()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Right Part</em>' containment reference.
+	 * @see #getRightPart()
+	 * @generated
+	 */
     void setRightPart(Expression value);
 
 } // Disjunction

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Equation.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Equation.java
@@ -10,11 +10,11 @@ package cz.zcu.yafmt.clang.bcl.model;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.Equation#getLeftPart <em>Left Part</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.Equation#getRightPart <em>Right Part</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getEquation()
  * @model
@@ -22,55 +22,55 @@ package cz.zcu.yafmt.clang.bcl.model;
  */
 public interface Equation extends Expression {
     /**
-     * Returns the value of the '<em><b>Left Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Left Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Left Part</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Left Part</em>' containment reference.
-     * @see #setLeftPart(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getEquation_LeftPart()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Left Part</em>' containment reference.
+	 * @see #setLeftPart(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getEquation_LeftPart()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getLeftPart();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Equation#getLeftPart <em>Left Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Equation#getLeftPart <em>Left Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Left Part</em>' containment reference.
-     * @see #getLeftPart()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Left Part</em>' containment reference.
+	 * @see #getLeftPart()
+	 * @generated
+	 */
     void setLeftPart(Expression value);
 
     /**
-     * Returns the value of the '<em><b>Right Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Right Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Right Part</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Right Part</em>' containment reference.
-     * @see #setRightPart(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getEquation_RightPart()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Right Part</em>' containment reference.
+	 * @see #setRightPart(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getEquation_RightPart()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getRightPart();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Equation#getRightPart <em>Right Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Equation#getRightPart <em>Right Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Right Part</em>' containment reference.
-     * @see #getRightPart()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Right Part</em>' containment reference.
+	 * @see #getRightPart()
+	 * @generated
+	 */
     void setRightPart(Expression value);
 
 } // Equation

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/ExistsContextualExpression.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/ExistsContextualExpression.java
@@ -10,11 +10,11 @@ package cz.zcu.yafmt.clang.bcl.model;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getContextId <em>Context Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getExpression <em>Expression</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getExistsContextualExpression()
  * @model
@@ -22,55 +22,55 @@ package cz.zcu.yafmt.clang.bcl.model;
  */
 public interface ExistsContextualExpression extends Expression {
     /**
-     * Returns the value of the '<em><b>Context Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Context Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Context Id</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Context Id</em>' attribute.
-     * @see #setContextId(String)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getExistsContextualExpression_ContextId()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Context Id</em>' attribute.
+	 * @see #setContextId(String)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getExistsContextualExpression_ContextId()
+	 * @model
+	 * @generated
+	 */
     String getContextId();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getContextId <em>Context Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getContextId <em>Context Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Context Id</em>' attribute.
-     * @see #getContextId()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Context Id</em>' attribute.
+	 * @see #getContextId()
+	 * @generated
+	 */
     void setContextId(String value);
 
     /**
-     * Returns the value of the '<em><b>Expression</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Expression</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Expression</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Expression</em>' containment reference.
-     * @see #setExpression(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getExistsContextualExpression_Expression()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Expression</em>' containment reference.
+	 * @see #setExpression(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getExistsContextualExpression_Expression()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getExpression();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getExpression <em>Expression</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getExpression <em>Expression</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Expression</em>' containment reference.
-     * @see #getExpression()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Expression</em>' containment reference.
+	 * @see #getExpression()
+	 * @generated
+	 */
     void setExpression(Expression value);
 
 } // ExistsContextualExpression

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/ForAllContextualExpression.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/ForAllContextualExpression.java
@@ -10,11 +10,11 @@ package cz.zcu.yafmt.clang.bcl.model;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getContextId <em>Context Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getExpression <em>Expression</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getForAllContextualExpression()
  * @model
@@ -22,55 +22,55 @@ package cz.zcu.yafmt.clang.bcl.model;
  */
 public interface ForAllContextualExpression extends Expression {
     /**
-     * Returns the value of the '<em><b>Context Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Context Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Context Id</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Context Id</em>' attribute.
-     * @see #setContextId(String)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getForAllContextualExpression_ContextId()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Context Id</em>' attribute.
+	 * @see #setContextId(String)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getForAllContextualExpression_ContextId()
+	 * @model
+	 * @generated
+	 */
     String getContextId();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getContextId <em>Context Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getContextId <em>Context Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Context Id</em>' attribute.
-     * @see #getContextId()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Context Id</em>' attribute.
+	 * @see #getContextId()
+	 * @generated
+	 */
     void setContextId(String value);
 
     /**
-     * Returns the value of the '<em><b>Expression</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Expression</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Expression</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Expression</em>' containment reference.
-     * @see #setExpression(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getForAllContextualExpression_Expression()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Expression</em>' containment reference.
+	 * @see #setExpression(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getForAllContextualExpression_Expression()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getExpression();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getExpression <em>Expression</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getExpression <em>Expression</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Expression</em>' containment reference.
-     * @see #getExpression()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Expression</em>' containment reference.
+	 * @see #getExpression()
+	 * @generated
+	 */
     void setExpression(Expression value);
 
 } // ForAllContextualExpression

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Implication.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Implication.java
@@ -10,11 +10,11 @@ package cz.zcu.yafmt.clang.bcl.model;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.Implication#getLeftPart <em>Left Part</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.Implication#getRightPart <em>Right Part</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getImplication()
  * @model
@@ -22,55 +22,55 @@ package cz.zcu.yafmt.clang.bcl.model;
  */
 public interface Implication extends Expression {
     /**
-     * Returns the value of the '<em><b>Left Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Left Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Left Part</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Left Part</em>' containment reference.
-     * @see #setLeftPart(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getImplication_LeftPart()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Left Part</em>' containment reference.
+	 * @see #setLeftPart(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getImplication_LeftPart()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getLeftPart();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Implication#getLeftPart <em>Left Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Implication#getLeftPart <em>Left Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Left Part</em>' containment reference.
-     * @see #getLeftPart()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Left Part</em>' containment reference.
+	 * @see #getLeftPart()
+	 * @generated
+	 */
     void setLeftPart(Expression value);
 
     /**
-     * Returns the value of the '<em><b>Right Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Right Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Right Part</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Right Part</em>' containment reference.
-     * @see #setRightPart(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getImplication_RightPart()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Right Part</em>' containment reference.
+	 * @see #setRightPart(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getImplication_RightPart()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getRightPart();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Implication#getRightPart <em>Right Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Implication#getRightPart <em>Right Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Right Part</em>' containment reference.
-     * @see #getRightPart()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Right Part</em>' containment reference.
+	 * @see #getRightPart()
+	 * @generated
+	 */
     void setRightPart(Expression value);
 
 } // Implication

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/ModelFactory.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/ModelFactory.java
@@ -14,92 +14,92 @@ import org.eclipse.emf.ecore.EFactory;
  */
 public interface ModelFactory extends EFactory {
     /**
-     * The singleton instance of the factory.
-     * <!-- begin-user-doc -->
+	 * The singleton instance of the factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     ModelFactory eINSTANCE = cz.zcu.yafmt.clang.bcl.model.impl.ModelFactoryImpl.init();
 
     /**
-     * Returns a new object of class '<em>For All Contextual Expression</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>For All Contextual Expression</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>For All Contextual Expression</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>For All Contextual Expression</em>'.
+	 * @generated
+	 */
     ForAllContextualExpression createForAllContextualExpression();
 
     /**
-     * Returns a new object of class '<em>Exists Contextual Expression</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Exists Contextual Expression</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Exists Contextual Expression</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Exists Contextual Expression</em>'.
+	 * @generated
+	 */
     ExistsContextualExpression createExistsContextualExpression();
 
     /**
-     * Returns a new object of class '<em>Equation</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Equation</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Equation</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Equation</em>'.
+	 * @generated
+	 */
     Equation createEquation();
 
     /**
-     * Returns a new object of class '<em>Implication</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Implication</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Implication</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Implication</em>'.
+	 * @generated
+	 */
     Implication createImplication();
 
     /**
-     * Returns a new object of class '<em>Disjunction</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Disjunction</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Disjunction</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Disjunction</em>'.
+	 * @generated
+	 */
     Disjunction createDisjunction();
 
     /**
-     * Returns a new object of class '<em>Conjunction</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Conjunction</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Conjunction</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Conjunction</em>'.
+	 * @generated
+	 */
     Conjunction createConjunction();
 
     /**
-     * Returns a new object of class '<em>Negation</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Negation</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Negation</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Negation</em>'.
+	 * @generated
+	 */
     Negation createNegation();
 
     /**
-     * Returns a new object of class '<em>Primary Expression</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Primary Expression</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Primary Expression</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Primary Expression</em>'.
+	 * @generated
+	 */
     PrimaryExpression createPrimaryExpression();
 
     /**
-     * Returns the package supported by this factory.
-     * <!-- begin-user-doc -->
+	 * Returns the package supported by this factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the package supported by this factory.
-     * @generated
-     */
+	 * @return the package supported by this factory.
+	 * @generated
+	 */
     ModelPackage getModelPackage();
 
 } //ModelFactory

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/ModelPackage.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/ModelPackage.java
@@ -24,589 +24,589 @@ import org.eclipse.emf.ecore.EReference;
  */
 public interface ModelPackage extends EPackage {
     /**
-     * The package name.
-     * <!-- begin-user-doc -->
+	 * The package name.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     String eNAME = "model";
 
     /**
-     * The package namespace URI.
-     * <!-- begin-user-doc -->
+	 * The package namespace URI.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     String eNS_URI = "http://zcu.cz/yafmt/clang/bcl";
 
     /**
-     * The package namespace name.
-     * <!-- begin-user-doc -->
+	 * The package namespace name.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     String eNS_PREFIX = "model";
 
     /**
-     * The singleton instance of the package.
-     * <!-- begin-user-doc -->
+	 * The singleton instance of the package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     ModelPackage eINSTANCE = cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl.init();
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ExpressionImpl <em>Expression</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ExpressionImpl <em>Expression</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ExpressionImpl
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getExpression()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ExpressionImpl
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getExpression()
+	 * @generated
+	 */
     int EXPRESSION = 0;
 
     /**
-     * The number of structural features of the '<em>Expression</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Expression</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int EXPRESSION_FEATURE_COUNT = 0;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl <em>For All Contextual Expression</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl <em>For All Contextual Expression</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getForAllContextualExpression()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getForAllContextualExpression()
+	 * @generated
+	 */
     int FOR_ALL_CONTEXTUAL_EXPRESSION = 1;
 
     /**
-     * The feature id for the '<em><b>Context Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Context Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID = EXPRESSION_FEATURE_COUNT + 0;
 
     /**
-     * The feature id for the '<em><b>Expression</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Expression</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION = EXPRESSION_FEATURE_COUNT + 1;
 
     /**
-     * The number of structural features of the '<em>For All Contextual Expression</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>For All Contextual Expression</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FOR_ALL_CONTEXTUAL_EXPRESSION_FEATURE_COUNT = EXPRESSION_FEATURE_COUNT + 2;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl <em>Exists Contextual Expression</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl <em>Exists Contextual Expression</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getExistsContextualExpression()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getExistsContextualExpression()
+	 * @generated
+	 */
     int EXISTS_CONTEXTUAL_EXPRESSION = 2;
 
     /**
-     * The feature id for the '<em><b>Context Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Context Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID = EXPRESSION_FEATURE_COUNT + 0;
 
     /**
-     * The feature id for the '<em><b>Expression</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Expression</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION = EXPRESSION_FEATURE_COUNT + 1;
 
     /**
-     * The number of structural features of the '<em>Exists Contextual Expression</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Exists Contextual Expression</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int EXISTS_CONTEXTUAL_EXPRESSION_FEATURE_COUNT = EXPRESSION_FEATURE_COUNT + 2;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl <em>Equation</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl <em>Equation</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getEquation()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getEquation()
+	 * @generated
+	 */
     int EQUATION = 3;
 
     /**
-     * The feature id for the '<em><b>Left Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Left Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int EQUATION__LEFT_PART = EXPRESSION_FEATURE_COUNT + 0;
 
     /**
-     * The feature id for the '<em><b>Right Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Right Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int EQUATION__RIGHT_PART = EXPRESSION_FEATURE_COUNT + 1;
 
     /**
-     * The number of structural features of the '<em>Equation</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Equation</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int EQUATION_FEATURE_COUNT = EXPRESSION_FEATURE_COUNT + 2;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl <em>Implication</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl <em>Implication</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getImplication()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getImplication()
+	 * @generated
+	 */
     int IMPLICATION = 4;
 
     /**
-     * The feature id for the '<em><b>Left Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Left Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int IMPLICATION__LEFT_PART = EXPRESSION_FEATURE_COUNT + 0;
 
     /**
-     * The feature id for the '<em><b>Right Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Right Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int IMPLICATION__RIGHT_PART = EXPRESSION_FEATURE_COUNT + 1;
 
     /**
-     * The number of structural features of the '<em>Implication</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Implication</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int IMPLICATION_FEATURE_COUNT = EXPRESSION_FEATURE_COUNT + 2;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl <em>Disjunction</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl <em>Disjunction</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getDisjunction()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getDisjunction()
+	 * @generated
+	 */
     int DISJUNCTION = 5;
 
     /**
-     * The feature id for the '<em><b>Left Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Left Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DISJUNCTION__LEFT_PART = EXPRESSION_FEATURE_COUNT + 0;
 
     /**
-     * The feature id for the '<em><b>Right Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Right Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DISJUNCTION__RIGHT_PART = EXPRESSION_FEATURE_COUNT + 1;
 
     /**
-     * The number of structural features of the '<em>Disjunction</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Disjunction</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DISJUNCTION_FEATURE_COUNT = EXPRESSION_FEATURE_COUNT + 2;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl <em>Conjunction</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl <em>Conjunction</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getConjunction()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getConjunction()
+	 * @generated
+	 */
     int CONJUNCTION = 6;
 
     /**
-     * The feature id for the '<em><b>Left Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Left Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int CONJUNCTION__LEFT_PART = EXPRESSION_FEATURE_COUNT + 0;
 
     /**
-     * The feature id for the '<em><b>Right Part</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Right Part</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int CONJUNCTION__RIGHT_PART = EXPRESSION_FEATURE_COUNT + 1;
 
     /**
-     * The number of structural features of the '<em>Conjunction</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Conjunction</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int CONJUNCTION_FEATURE_COUNT = EXPRESSION_FEATURE_COUNT + 2;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.NegationImpl <em>Negation</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.NegationImpl <em>Negation</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.NegationImpl
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getNegation()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.NegationImpl
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getNegation()
+	 * @generated
+	 */
     int NEGATION = 7;
 
     /**
-     * The feature id for the '<em><b>Expression</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Expression</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int NEGATION__EXPRESSION = EXPRESSION_FEATURE_COUNT + 0;
 
     /**
-     * The number of structural features of the '<em>Negation</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Negation</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int NEGATION_FEATURE_COUNT = EXPRESSION_FEATURE_COUNT + 1;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.PrimaryExpressionImpl <em>Primary Expression</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.PrimaryExpressionImpl <em>Primary Expression</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.PrimaryExpressionImpl
-     * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getPrimaryExpression()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.PrimaryExpressionImpl
+	 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getPrimaryExpression()
+	 * @generated
+	 */
     int PRIMARY_EXPRESSION = 8;
 
     /**
-     * The feature id for the '<em><b>Feature Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Feature Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int PRIMARY_EXPRESSION__FEATURE_ID = EXPRESSION_FEATURE_COUNT + 0;
 
     /**
-     * The number of structural features of the '<em>Primary Expression</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Primary Expression</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int PRIMARY_EXPRESSION_FEATURE_COUNT = EXPRESSION_FEATURE_COUNT + 1;
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Expression <em>Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Expression <em>Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Expression</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Expression
-     * @generated
-     */
+	 * @return the meta object for class '<em>Expression</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Expression
+	 * @generated
+	 */
     EClass getExpression();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression <em>For All Contextual Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression <em>For All Contextual Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>For All Contextual Expression</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression
-     * @generated
-     */
+	 * @return the meta object for class '<em>For All Contextual Expression</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression
+	 * @generated
+	 */
     EClass getForAllContextualExpression();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getContextId <em>Context Id</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getContextId <em>Context Id</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Context Id</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getContextId()
-     * @see #getForAllContextualExpression()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Context Id</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getContextId()
+	 * @see #getForAllContextualExpression()
+	 * @generated
+	 */
     EAttribute getForAllContextualExpression_ContextId();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getExpression <em>Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getExpression <em>Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Expression</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getExpression()
-     * @see #getForAllContextualExpression()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Expression</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression#getExpression()
+	 * @see #getForAllContextualExpression()
+	 * @generated
+	 */
     EReference getForAllContextualExpression_Expression();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression <em>Exists Contextual Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression <em>Exists Contextual Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Exists Contextual Expression</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression
-     * @generated
-     */
+	 * @return the meta object for class '<em>Exists Contextual Expression</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression
+	 * @generated
+	 */
     EClass getExistsContextualExpression();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getContextId <em>Context Id</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getContextId <em>Context Id</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Context Id</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getContextId()
-     * @see #getExistsContextualExpression()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Context Id</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getContextId()
+	 * @see #getExistsContextualExpression()
+	 * @generated
+	 */
     EAttribute getExistsContextualExpression_ContextId();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getExpression <em>Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getExpression <em>Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Expression</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getExpression()
-     * @see #getExistsContextualExpression()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Expression</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression#getExpression()
+	 * @see #getExistsContextualExpression()
+	 * @generated
+	 */
     EReference getExistsContextualExpression_Expression();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Equation <em>Equation</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Equation <em>Equation</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Equation</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Equation
-     * @generated
-     */
+	 * @return the meta object for class '<em>Equation</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Equation
+	 * @generated
+	 */
     EClass getEquation();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Equation#getLeftPart <em>Left Part</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Equation#getLeftPart <em>Left Part</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Left Part</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Equation#getLeftPart()
-     * @see #getEquation()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Left Part</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Equation#getLeftPart()
+	 * @see #getEquation()
+	 * @generated
+	 */
     EReference getEquation_LeftPart();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Equation#getRightPart <em>Right Part</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Equation#getRightPart <em>Right Part</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Right Part</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Equation#getRightPart()
-     * @see #getEquation()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Right Part</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Equation#getRightPart()
+	 * @see #getEquation()
+	 * @generated
+	 */
     EReference getEquation_RightPart();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Implication <em>Implication</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Implication <em>Implication</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Implication</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Implication
-     * @generated
-     */
+	 * @return the meta object for class '<em>Implication</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Implication
+	 * @generated
+	 */
     EClass getImplication();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Implication#getLeftPart <em>Left Part</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Implication#getLeftPart <em>Left Part</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Left Part</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Implication#getLeftPart()
-     * @see #getImplication()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Left Part</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Implication#getLeftPart()
+	 * @see #getImplication()
+	 * @generated
+	 */
     EReference getImplication_LeftPart();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Implication#getRightPart <em>Right Part</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Implication#getRightPart <em>Right Part</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Right Part</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Implication#getRightPart()
-     * @see #getImplication()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Right Part</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Implication#getRightPart()
+	 * @see #getImplication()
+	 * @generated
+	 */
     EReference getImplication_RightPart();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction <em>Disjunction</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction <em>Disjunction</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Disjunction</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Disjunction
-     * @generated
-     */
+	 * @return the meta object for class '<em>Disjunction</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Disjunction
+	 * @generated
+	 */
     EClass getDisjunction();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getLeftPart <em>Left Part</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getLeftPart <em>Left Part</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Left Part</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Disjunction#getLeftPart()
-     * @see #getDisjunction()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Left Part</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Disjunction#getLeftPart()
+	 * @see #getDisjunction()
+	 * @generated
+	 */
     EReference getDisjunction_LeftPart();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getRightPart <em>Right Part</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction#getRightPart <em>Right Part</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Right Part</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Disjunction#getRightPart()
-     * @see #getDisjunction()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Right Part</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Disjunction#getRightPart()
+	 * @see #getDisjunction()
+	 * @generated
+	 */
     EReference getDisjunction_RightPart();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction <em>Conjunction</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction <em>Conjunction</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Conjunction</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Conjunction
-     * @generated
-     */
+	 * @return the meta object for class '<em>Conjunction</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Conjunction
+	 * @generated
+	 */
     EClass getConjunction();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getLeftPart <em>Left Part</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getLeftPart <em>Left Part</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Left Part</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Conjunction#getLeftPart()
-     * @see #getConjunction()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Left Part</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Conjunction#getLeftPart()
+	 * @see #getConjunction()
+	 * @generated
+	 */
     EReference getConjunction_LeftPart();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getRightPart <em>Right Part</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction#getRightPart <em>Right Part</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Right Part</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Conjunction#getRightPart()
-     * @see #getConjunction()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Right Part</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Conjunction#getRightPart()
+	 * @see #getConjunction()
+	 * @generated
+	 */
     EReference getConjunction_RightPart();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Negation <em>Negation</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.Negation <em>Negation</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Negation</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Negation
-     * @generated
-     */
+	 * @return the meta object for class '<em>Negation</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Negation
+	 * @generated
+	 */
     EClass getNegation();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Negation#getExpression <em>Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.clang.bcl.model.Negation#getExpression <em>Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Expression</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.Negation#getExpression()
-     * @see #getNegation()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Expression</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Negation#getExpression()
+	 * @see #getNegation()
+	 * @generated
+	 */
     EReference getNegation_Expression();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.PrimaryExpression <em>Primary Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.clang.bcl.model.PrimaryExpression <em>Primary Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Primary Expression</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.PrimaryExpression
-     * @generated
-     */
+	 * @return the meta object for class '<em>Primary Expression</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.PrimaryExpression
+	 * @generated
+	 */
     EClass getPrimaryExpression();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.clang.bcl.model.PrimaryExpression#getFeatureId <em>Feature Id</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.clang.bcl.model.PrimaryExpression#getFeatureId <em>Feature Id</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Feature Id</em>'.
-     * @see cz.zcu.yafmt.clang.bcl.model.PrimaryExpression#getFeatureId()
-     * @see #getPrimaryExpression()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Feature Id</em>'.
+	 * @see cz.zcu.yafmt.clang.bcl.model.PrimaryExpression#getFeatureId()
+	 * @see #getPrimaryExpression()
+	 * @generated
+	 */
     EAttribute getPrimaryExpression_FeatureId();
 
     /**
-     * Returns the factory that creates the instances of the model.
-     * <!-- begin-user-doc -->
+	 * Returns the factory that creates the instances of the model.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the factory that creates the instances of the model.
-     * @generated
-     */
+	 * @return the factory that creates the instances of the model.
+	 * @generated
+	 */
     ModelFactory getModelFactory();
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * Defines literals for the meta objects that represent
      * <ul>
      *   <li>each class,</li>
@@ -615,209 +615,209 @@ public interface ModelPackage extends EPackage {
      *   <li>and each data type</li>
      * </ul>
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     interface Literals {
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ExpressionImpl <em>Expression</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ExpressionImpl <em>Expression</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ExpressionImpl
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getExpression()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ExpressionImpl
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getExpression()
+		 * @generated
+		 */
         EClass EXPRESSION = eINSTANCE.getExpression();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl <em>For All Contextual Expression</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl <em>For All Contextual Expression</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getForAllContextualExpression()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getForAllContextualExpression()
+		 * @generated
+		 */
         EClass FOR_ALL_CONTEXTUAL_EXPRESSION = eINSTANCE.getForAllContextualExpression();
 
         /**
-         * The meta object literal for the '<em><b>Context Id</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Context Id</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID = eINSTANCE.getForAllContextualExpression_ContextId();
 
         /**
-         * The meta object literal for the '<em><b>Expression</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Expression</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION = eINSTANCE.getForAllContextualExpression_Expression();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl <em>Exists Contextual Expression</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl <em>Exists Contextual Expression</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getExistsContextualExpression()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getExistsContextualExpression()
+		 * @generated
+		 */
         EClass EXISTS_CONTEXTUAL_EXPRESSION = eINSTANCE.getExistsContextualExpression();
 
         /**
-         * The meta object literal for the '<em><b>Context Id</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Context Id</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID = eINSTANCE.getExistsContextualExpression_ContextId();
 
         /**
-         * The meta object literal for the '<em><b>Expression</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Expression</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION = eINSTANCE.getExistsContextualExpression_Expression();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl <em>Equation</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl <em>Equation</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getEquation()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getEquation()
+		 * @generated
+		 */
         EClass EQUATION = eINSTANCE.getEquation();
 
         /**
-         * The meta object literal for the '<em><b>Left Part</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Left Part</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference EQUATION__LEFT_PART = eINSTANCE.getEquation_LeftPart();
 
         /**
-         * The meta object literal for the '<em><b>Right Part</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Right Part</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference EQUATION__RIGHT_PART = eINSTANCE.getEquation_RightPart();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl <em>Implication</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl <em>Implication</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getImplication()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getImplication()
+		 * @generated
+		 */
         EClass IMPLICATION = eINSTANCE.getImplication();
 
         /**
-         * The meta object literal for the '<em><b>Left Part</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Left Part</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference IMPLICATION__LEFT_PART = eINSTANCE.getImplication_LeftPart();
 
         /**
-         * The meta object literal for the '<em><b>Right Part</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Right Part</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference IMPLICATION__RIGHT_PART = eINSTANCE.getImplication_RightPart();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl <em>Disjunction</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl <em>Disjunction</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getDisjunction()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getDisjunction()
+		 * @generated
+		 */
         EClass DISJUNCTION = eINSTANCE.getDisjunction();
 
         /**
-         * The meta object literal for the '<em><b>Left Part</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Left Part</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference DISJUNCTION__LEFT_PART = eINSTANCE.getDisjunction_LeftPart();
 
         /**
-         * The meta object literal for the '<em><b>Right Part</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Right Part</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference DISJUNCTION__RIGHT_PART = eINSTANCE.getDisjunction_RightPart();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl <em>Conjunction</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl <em>Conjunction</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getConjunction()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getConjunction()
+		 * @generated
+		 */
         EClass CONJUNCTION = eINSTANCE.getConjunction();
 
         /**
-         * The meta object literal for the '<em><b>Left Part</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Left Part</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference CONJUNCTION__LEFT_PART = eINSTANCE.getConjunction_LeftPart();
 
         /**
-         * The meta object literal for the '<em><b>Right Part</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Right Part</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference CONJUNCTION__RIGHT_PART = eINSTANCE.getConjunction_RightPart();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.NegationImpl <em>Negation</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.NegationImpl <em>Negation</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.NegationImpl
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getNegation()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.NegationImpl
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getNegation()
+		 * @generated
+		 */
         EClass NEGATION = eINSTANCE.getNegation();
 
         /**
-         * The meta object literal for the '<em><b>Expression</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Expression</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference NEGATION__EXPRESSION = eINSTANCE.getNegation_Expression();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.PrimaryExpressionImpl <em>Primary Expression</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.clang.bcl.model.impl.PrimaryExpressionImpl <em>Primary Expression</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.PrimaryExpressionImpl
-         * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getPrimaryExpression()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.PrimaryExpressionImpl
+		 * @see cz.zcu.yafmt.clang.bcl.model.impl.ModelPackageImpl#getPrimaryExpression()
+		 * @generated
+		 */
         EClass PRIMARY_EXPRESSION = eINSTANCE.getPrimaryExpression();
 
         /**
-         * The meta object literal for the '<em><b>Feature Id</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Feature Id</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute PRIMARY_EXPRESSION__FEATURE_ID = eINSTANCE.getPrimaryExpression_FeatureId();
 
     }

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Negation.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/Negation.java
@@ -10,10 +10,10 @@ package cz.zcu.yafmt.clang.bcl.model;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.Negation#getExpression <em>Expression</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getNegation()
  * @model
@@ -22,28 +22,28 @@ package cz.zcu.yafmt.clang.bcl.model;
 public interface Negation extends Expression {
 
     /**
-     * Returns the value of the '<em><b>Expression</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Expression</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Expression</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Expression</em>' containment reference.
-     * @see #setExpression(Expression)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getNegation_Expression()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Expression</em>' containment reference.
+	 * @see #setExpression(Expression)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getNegation_Expression()
+	 * @model containment="true"
+	 * @generated
+	 */
     Expression getExpression();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Negation#getExpression <em>Expression</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.Negation#getExpression <em>Expression</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Expression</em>' containment reference.
-     * @see #getExpression()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Expression</em>' containment reference.
+	 * @see #getExpression()
+	 * @generated
+	 */
     void setExpression(Expression value);
 } // Negation

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/PrimaryExpression.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/PrimaryExpression.java
@@ -10,10 +10,10 @@ package cz.zcu.yafmt.clang.bcl.model;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.PrimaryExpression#getFeatureId <em>Feature Id</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getPrimaryExpression()
  * @model
@@ -21,29 +21,29 @@ package cz.zcu.yafmt.clang.bcl.model;
  */
 public interface PrimaryExpression extends Expression {
     /**
-     * Returns the value of the '<em><b>Feature Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Feature Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Feature Id</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Feature Id</em>' attribute.
-     * @see #setFeatureId(String)
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getPrimaryExpression_FeatureId()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Feature Id</em>' attribute.
+	 * @see #setFeatureId(String)
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#getPrimaryExpression_FeatureId()
+	 * @model
+	 * @generated
+	 */
     String getFeatureId();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.PrimaryExpression#getFeatureId <em>Feature Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.clang.bcl.model.PrimaryExpression#getFeatureId <em>Feature Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Feature Id</em>' attribute.
-     * @see #getFeatureId()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Feature Id</em>' attribute.
+	 * @see #getFeatureId()
+	 * @generated
+	 */
     void setFeatureId(String value);
 
 } // PrimaryExpression

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ConjunctionImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ConjunctionImpl.java
@@ -23,221 +23,221 @@ import cz.zcu.yafmt.model.fc.Selection;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl#getLeftPart <em>Left Part</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.ConjunctionImpl#getRightPart <em>Right Part</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class ConjunctionImpl extends ExpressionImpl implements Conjunction {
     /**
-     * The cached value of the '{@link #getLeftPart() <em>Left Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getLeftPart() <em>Left Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getLeftPart()
-     * @generated
-     * @ordered
-     */
+	 * @see #getLeftPart()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression leftPart;
     /**
-     * The cached value of the '{@link #getRightPart() <em>Right Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getRightPart() <em>Right Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getRightPart()
-     * @generated
-     * @ordered
-     */
+	 * @see #getRightPart()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression rightPart;
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ConjunctionImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return ModelPackage.Literals.CONJUNCTION;
-    }
+		return ModelPackage.Literals.CONJUNCTION;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Expression getLeftPart() {
-        return leftPart;
-    }
+		return leftPart;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetLeftPart(Expression newLeftPart, NotificationChain msgs) {
-        Expression oldLeftPart = leftPart;
-        leftPart = newLeftPart;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.CONJUNCTION__LEFT_PART, oldLeftPart, newLeftPart);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldLeftPart = leftPart;
+		leftPart = newLeftPart;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.CONJUNCTION__LEFT_PART, oldLeftPart, newLeftPart);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setLeftPart(Expression newLeftPart) {
-        if (newLeftPart != leftPart) {
-            NotificationChain msgs = null;
-            if (leftPart != null)
-                msgs = ((InternalEObject)leftPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.CONJUNCTION__LEFT_PART, null, msgs);
-            if (newLeftPart != null)
-                msgs = ((InternalEObject)newLeftPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.CONJUNCTION__LEFT_PART, null, msgs);
-            msgs = basicSetLeftPart(newLeftPart, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.CONJUNCTION__LEFT_PART, newLeftPart, newLeftPart));
-    }
+		if (newLeftPart != leftPart) {
+			NotificationChain msgs = null;
+			if (leftPart != null)
+				msgs = ((InternalEObject)leftPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.CONJUNCTION__LEFT_PART, null, msgs);
+			if (newLeftPart != null)
+				msgs = ((InternalEObject)newLeftPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.CONJUNCTION__LEFT_PART, null, msgs);
+			msgs = basicSetLeftPart(newLeftPart, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.CONJUNCTION__LEFT_PART, newLeftPart, newLeftPart));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Expression getRightPart() {
-        return rightPart;
-    }
+		return rightPart;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetRightPart(Expression newRightPart, NotificationChain msgs) {
-        Expression oldRightPart = rightPart;
-        rightPart = newRightPart;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.CONJUNCTION__RIGHT_PART, oldRightPart, newRightPart);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldRightPart = rightPart;
+		rightPart = newRightPart;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.CONJUNCTION__RIGHT_PART, oldRightPart, newRightPart);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setRightPart(Expression newRightPart) {
-        if (newRightPart != rightPart) {
-            NotificationChain msgs = null;
-            if (rightPart != null)
-                msgs = ((InternalEObject)rightPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.CONJUNCTION__RIGHT_PART, null, msgs);
-            if (newRightPart != null)
-                msgs = ((InternalEObject)newRightPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.CONJUNCTION__RIGHT_PART, null, msgs);
-            msgs = basicSetRightPart(newRightPart, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.CONJUNCTION__RIGHT_PART, newRightPart, newRightPart));
-    }
+		if (newRightPart != rightPart) {
+			NotificationChain msgs = null;
+			if (rightPart != null)
+				msgs = ((InternalEObject)rightPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.CONJUNCTION__RIGHT_PART, null, msgs);
+			if (newRightPart != null)
+				msgs = ((InternalEObject)newRightPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.CONJUNCTION__RIGHT_PART, null, msgs);
+			msgs = basicSetRightPart(newRightPart, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.CONJUNCTION__RIGHT_PART, newRightPart, newRightPart));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case ModelPackage.CONJUNCTION__LEFT_PART:
-                return basicSetLeftPart(null, msgs);
-            case ModelPackage.CONJUNCTION__RIGHT_PART:
-                return basicSetRightPart(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case ModelPackage.CONJUNCTION__LEFT_PART:
+				return basicSetLeftPart(null, msgs);
+			case ModelPackage.CONJUNCTION__RIGHT_PART:
+				return basicSetRightPart(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case ModelPackage.CONJUNCTION__LEFT_PART:
-                return getLeftPart();
-            case ModelPackage.CONJUNCTION__RIGHT_PART:
-                return getRightPart();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case ModelPackage.CONJUNCTION__LEFT_PART:
+				return getLeftPart();
+			case ModelPackage.CONJUNCTION__RIGHT_PART:
+				return getRightPart();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case ModelPackage.CONJUNCTION__LEFT_PART:
-                setLeftPart((Expression)newValue);
-                return;
-            case ModelPackage.CONJUNCTION__RIGHT_PART:
-                setRightPart((Expression)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case ModelPackage.CONJUNCTION__LEFT_PART:
+				setLeftPart((Expression)newValue);
+				return;
+			case ModelPackage.CONJUNCTION__RIGHT_PART:
+				setRightPart((Expression)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case ModelPackage.CONJUNCTION__LEFT_PART:
-                setLeftPart((Expression)null);
-                return;
-            case ModelPackage.CONJUNCTION__RIGHT_PART:
-                setRightPart((Expression)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.CONJUNCTION__LEFT_PART:
+				setLeftPart((Expression)null);
+				return;
+			case ModelPackage.CONJUNCTION__RIGHT_PART:
+				setRightPart((Expression)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case ModelPackage.CONJUNCTION__LEFT_PART:
-                return leftPart != null;
-            case ModelPackage.CONJUNCTION__RIGHT_PART:
-                return rightPart != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.CONJUNCTION__LEFT_PART:
+				return leftPart != null;
+			case ModelPackage.CONJUNCTION__RIGHT_PART:
+				return rightPart != null;
+		}
+		return super.eIsSet(featureID);
+	}
     
     @Override
     public void retrieveFeatureIds(Set<String> ids) {

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/DisjunctionImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/DisjunctionImpl.java
@@ -22,208 +22,208 @@ import cz.zcu.yafmt.model.fc.Selection;
  * <em><b>Disjunction</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl#getLeftPart <em>Left Part</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.DisjunctionImpl#getRightPart <em>Right Part</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class DisjunctionImpl extends ExpressionImpl implements Disjunction {
 
     /**
-     * The cached value of the '{@link #getLeftPart() <em>Left Part</em>}' containment reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @see #getLeftPart()
-     * @generated
-     * @ordered
-     */
+	 * The cached value of the '{@link #getLeftPart() <em>Left Part</em>}' containment reference.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @see #getLeftPart()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression leftPart;
     /**
-     * The cached value of the '{@link #getRightPart() <em>Right Part</em>}' containment reference.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @see #getRightPart()
-     * @generated
-     * @ordered
-     */
+	 * The cached value of the '{@link #getRightPart() <em>Right Part</em>}' containment reference.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @see #getRightPart()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression rightPart;
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     protected DisjunctionImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return ModelPackage.Literals.DISJUNCTION;
-    }
+		return ModelPackage.Literals.DISJUNCTION;
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     public Expression getLeftPart() {
-        return leftPart;
-    }
+		return leftPart;
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     public NotificationChain basicSetLeftPart(Expression newLeftPart, NotificationChain msgs) {
-        Expression oldLeftPart = leftPart;
-        leftPart = newLeftPart;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.DISJUNCTION__LEFT_PART, oldLeftPart, newLeftPart);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldLeftPart = leftPart;
+		leftPart = newLeftPart;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.DISJUNCTION__LEFT_PART, oldLeftPart, newLeftPart);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     public void setLeftPart(Expression newLeftPart) {
-        if (newLeftPart != leftPart) {
-            NotificationChain msgs = null;
-            if (leftPart != null)
-                msgs = ((InternalEObject)leftPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.DISJUNCTION__LEFT_PART, null, msgs);
-            if (newLeftPart != null)
-                msgs = ((InternalEObject)newLeftPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.DISJUNCTION__LEFT_PART, null, msgs);
-            msgs = basicSetLeftPart(newLeftPart, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.DISJUNCTION__LEFT_PART, newLeftPart, newLeftPart));
-    }
+		if (newLeftPart != leftPart) {
+			NotificationChain msgs = null;
+			if (leftPart != null)
+				msgs = ((InternalEObject)leftPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.DISJUNCTION__LEFT_PART, null, msgs);
+			if (newLeftPart != null)
+				msgs = ((InternalEObject)newLeftPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.DISJUNCTION__LEFT_PART, null, msgs);
+			msgs = basicSetLeftPart(newLeftPart, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.DISJUNCTION__LEFT_PART, newLeftPart, newLeftPart));
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     public Expression getRightPart() {
-        return rightPart;
-    }
+		return rightPart;
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     public NotificationChain basicSetRightPart(Expression newRightPart, NotificationChain msgs) {
-        Expression oldRightPart = rightPart;
-        rightPart = newRightPart;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.DISJUNCTION__RIGHT_PART, oldRightPart, newRightPart);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldRightPart = rightPart;
+		rightPart = newRightPart;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.DISJUNCTION__RIGHT_PART, oldRightPart, newRightPart);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     public void setRightPart(Expression newRightPart) {
-        if (newRightPart != rightPart) {
-            NotificationChain msgs = null;
-            if (rightPart != null)
-                msgs = ((InternalEObject)rightPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.DISJUNCTION__RIGHT_PART, null, msgs);
-            if (newRightPart != null)
-                msgs = ((InternalEObject)newRightPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.DISJUNCTION__RIGHT_PART, null, msgs);
-            msgs = basicSetRightPart(newRightPart, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.DISJUNCTION__RIGHT_PART, newRightPart, newRightPart));
-    }
+		if (newRightPart != rightPart) {
+			NotificationChain msgs = null;
+			if (rightPart != null)
+				msgs = ((InternalEObject)rightPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.DISJUNCTION__RIGHT_PART, null, msgs);
+			if (newRightPart != null)
+				msgs = ((InternalEObject)newRightPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.DISJUNCTION__RIGHT_PART, null, msgs);
+			msgs = basicSetRightPart(newRightPart, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.DISJUNCTION__RIGHT_PART, newRightPart, newRightPart));
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case ModelPackage.DISJUNCTION__LEFT_PART:
-                return basicSetLeftPart(null, msgs);
-            case ModelPackage.DISJUNCTION__RIGHT_PART:
-                return basicSetRightPart(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case ModelPackage.DISJUNCTION__LEFT_PART:
+				return basicSetLeftPart(null, msgs);
+			case ModelPackage.DISJUNCTION__RIGHT_PART:
+				return basicSetRightPart(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case ModelPackage.DISJUNCTION__LEFT_PART:
-                return getLeftPart();
-            case ModelPackage.DISJUNCTION__RIGHT_PART:
-                return getRightPart();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case ModelPackage.DISJUNCTION__LEFT_PART:
+				return getLeftPart();
+			case ModelPackage.DISJUNCTION__RIGHT_PART:
+				return getRightPart();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case ModelPackage.DISJUNCTION__LEFT_PART:
-                setLeftPart((Expression)newValue);
-                return;
-            case ModelPackage.DISJUNCTION__RIGHT_PART:
-                setRightPart((Expression)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case ModelPackage.DISJUNCTION__LEFT_PART:
+				setLeftPart((Expression)newValue);
+				return;
+			case ModelPackage.DISJUNCTION__RIGHT_PART:
+				setRightPart((Expression)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case ModelPackage.DISJUNCTION__LEFT_PART:
-                setLeftPart((Expression)null);
-                return;
-            case ModelPackage.DISJUNCTION__RIGHT_PART:
-                setRightPart((Expression)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.DISJUNCTION__LEFT_PART:
+				setLeftPart((Expression)null);
+				return;
+			case ModelPackage.DISJUNCTION__RIGHT_PART:
+				setRightPart((Expression)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     * @generated
-     */
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case ModelPackage.DISJUNCTION__LEFT_PART:
-                return leftPart != null;
-            case ModelPackage.DISJUNCTION__RIGHT_PART:
-                return rightPart != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.DISJUNCTION__LEFT_PART:
+				return leftPart != null;
+			case ModelPackage.DISJUNCTION__RIGHT_PART:
+				return rightPart != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     @Override
     public void retrieveFeatureIds(Set<String> ids) {

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/EquationImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/EquationImpl.java
@@ -25,223 +25,223 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl#getLeftPart <em>Left Part</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.EquationImpl#getRightPart <em>Right Part</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class EquationImpl extends ExpressionImpl implements Equation {
     /**
-     * The cached value of the '{@link #getLeftPart() <em>Left Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getLeftPart() <em>Left Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getLeftPart()
-     * @generated
-     * @ordered
-     */
+	 * @see #getLeftPart()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression leftPart;
 
     /**
-     * The cached value of the '{@link #getRightPart() <em>Right Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getRightPart() <em>Right Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getRightPart()
-     * @generated
-     * @ordered
-     */
+	 * @see #getRightPart()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression rightPart;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected EquationImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return ModelPackage.Literals.EQUATION;
-    }
+		return ModelPackage.Literals.EQUATION;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Expression getLeftPart() {
-        return leftPart;
-    }
+		return leftPart;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetLeftPart(Expression newLeftPart, NotificationChain msgs) {
-        Expression oldLeftPart = leftPart;
-        leftPart = newLeftPart;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.EQUATION__LEFT_PART, oldLeftPart, newLeftPart);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldLeftPart = leftPart;
+		leftPart = newLeftPart;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.EQUATION__LEFT_PART, oldLeftPart, newLeftPart);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setLeftPart(Expression newLeftPart) {
-        if (newLeftPart != leftPart) {
-            NotificationChain msgs = null;
-            if (leftPart != null)
-                msgs = ((InternalEObject)leftPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EQUATION__LEFT_PART, null, msgs);
-            if (newLeftPart != null)
-                msgs = ((InternalEObject)newLeftPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EQUATION__LEFT_PART, null, msgs);
-            msgs = basicSetLeftPart(newLeftPart, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.EQUATION__LEFT_PART, newLeftPart, newLeftPart));
-    }
+		if (newLeftPart != leftPart) {
+			NotificationChain msgs = null;
+			if (leftPart != null)
+				msgs = ((InternalEObject)leftPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EQUATION__LEFT_PART, null, msgs);
+			if (newLeftPart != null)
+				msgs = ((InternalEObject)newLeftPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EQUATION__LEFT_PART, null, msgs);
+			msgs = basicSetLeftPart(newLeftPart, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.EQUATION__LEFT_PART, newLeftPart, newLeftPart));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Expression getRightPart() {
-        return rightPart;
-    }
+		return rightPart;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetRightPart(Expression newRightPart, NotificationChain msgs) {
-        Expression oldRightPart = rightPart;
-        rightPart = newRightPart;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.EQUATION__RIGHT_PART, oldRightPart, newRightPart);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldRightPart = rightPart;
+		rightPart = newRightPart;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.EQUATION__RIGHT_PART, oldRightPart, newRightPart);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setRightPart(Expression newRightPart) {
-        if (newRightPart != rightPart) {
-            NotificationChain msgs = null;
-            if (rightPart != null)
-                msgs = ((InternalEObject)rightPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EQUATION__RIGHT_PART, null, msgs);
-            if (newRightPart != null)
-                msgs = ((InternalEObject)newRightPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EQUATION__RIGHT_PART, null, msgs);
-            msgs = basicSetRightPart(newRightPart, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.EQUATION__RIGHT_PART, newRightPart, newRightPart));
-    }
+		if (newRightPart != rightPart) {
+			NotificationChain msgs = null;
+			if (rightPart != null)
+				msgs = ((InternalEObject)rightPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EQUATION__RIGHT_PART, null, msgs);
+			if (newRightPart != null)
+				msgs = ((InternalEObject)newRightPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EQUATION__RIGHT_PART, null, msgs);
+			msgs = basicSetRightPart(newRightPart, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.EQUATION__RIGHT_PART, newRightPart, newRightPart));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case ModelPackage.EQUATION__LEFT_PART:
-                return basicSetLeftPart(null, msgs);
-            case ModelPackage.EQUATION__RIGHT_PART:
-                return basicSetRightPart(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case ModelPackage.EQUATION__LEFT_PART:
+				return basicSetLeftPart(null, msgs);
+			case ModelPackage.EQUATION__RIGHT_PART:
+				return basicSetRightPart(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case ModelPackage.EQUATION__LEFT_PART:
-                return getLeftPart();
-            case ModelPackage.EQUATION__RIGHT_PART:
-                return getRightPart();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case ModelPackage.EQUATION__LEFT_PART:
+				return getLeftPart();
+			case ModelPackage.EQUATION__RIGHT_PART:
+				return getRightPart();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case ModelPackage.EQUATION__LEFT_PART:
-                setLeftPart((Expression)newValue);
-                return;
-            case ModelPackage.EQUATION__RIGHT_PART:
-                setRightPart((Expression)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case ModelPackage.EQUATION__LEFT_PART:
+				setLeftPart((Expression)newValue);
+				return;
+			case ModelPackage.EQUATION__RIGHT_PART:
+				setRightPart((Expression)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case ModelPackage.EQUATION__LEFT_PART:
-                setLeftPart((Expression)null);
-                return;
-            case ModelPackage.EQUATION__RIGHT_PART:
-                setRightPart((Expression)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.EQUATION__LEFT_PART:
+				setLeftPart((Expression)null);
+				return;
+			case ModelPackage.EQUATION__RIGHT_PART:
+				setRightPart((Expression)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case ModelPackage.EQUATION__LEFT_PART:
-                return leftPart != null;
-            case ModelPackage.EQUATION__RIGHT_PART:
-                return rightPart != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.EQUATION__LEFT_PART:
+				return leftPart != null;
+			case ModelPackage.EQUATION__RIGHT_PART:
+				return rightPart != null;
+		}
+		return super.eIsSet(featureID);
+	}
     
     @Override
     public void retrieveFeatureIds(Set<String> ids) {

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ExistsContextualExpressionImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ExistsContextualExpressionImpl.java
@@ -26,225 +26,225 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl#getContextId <em>Context Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.ExistsContextualExpressionImpl#getExpression <em>Expression</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class ExistsContextualExpressionImpl extends ExpressionImpl implements ExistsContextualExpression {
     /**
-     * The default value of the '{@link #getContextId() <em>Context Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getContextId() <em>Context Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getContextId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getContextId()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String CONTEXT_ID_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getContextId() <em>Context Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getContextId() <em>Context Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getContextId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getContextId()
+	 * @generated
+	 * @ordered
+	 */
     protected String contextId = CONTEXT_ID_EDEFAULT;
 
     /**
-     * The cached value of the '{@link #getExpression() <em>Expression</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getExpression() <em>Expression</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getExpression()
-     * @generated
-     * @ordered
-     */
+	 * @see #getExpression()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression expression;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ExistsContextualExpressionImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return ModelPackage.Literals.EXISTS_CONTEXTUAL_EXPRESSION;
-    }
+		return ModelPackage.Literals.EXISTS_CONTEXTUAL_EXPRESSION;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getContextId() {
-        return contextId;
-    }
+		return contextId;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setContextId(String newContextId) {
-        String oldContextId = contextId;
-        contextId = newContextId;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID, oldContextId, contextId));
-    }
+		String oldContextId = contextId;
+		contextId = newContextId;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID, oldContextId, contextId));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Expression getExpression() {
-        return expression;
-    }
+		return expression;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetExpression(Expression newExpression, NotificationChain msgs) {
-        Expression oldExpression = expression;
-        expression = newExpression;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION, oldExpression, newExpression);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldExpression = expression;
+		expression = newExpression;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION, oldExpression, newExpression);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setExpression(Expression newExpression) {
-        if (newExpression != expression) {
-            NotificationChain msgs = null;
-            if (expression != null)
-                msgs = ((InternalEObject)expression).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION, null, msgs);
-            if (newExpression != null)
-                msgs = ((InternalEObject)newExpression).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION, null, msgs);
-            msgs = basicSetExpression(newExpression, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION, newExpression, newExpression));
-    }
+		if (newExpression != expression) {
+			NotificationChain msgs = null;
+			if (expression != null)
+				msgs = ((InternalEObject)expression).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION, null, msgs);
+			if (newExpression != null)
+				msgs = ((InternalEObject)newExpression).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION, null, msgs);
+			msgs = basicSetExpression(newExpression, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION, newExpression, newExpression));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                return basicSetExpression(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				return basicSetExpression(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
-                return getContextId();
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                return getExpression();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
+				return getContextId();
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				return getExpression();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
-                setContextId((String)newValue);
-                return;
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                setExpression((Expression)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
+				setContextId((String)newValue);
+				return;
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				setExpression((Expression)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
-                setContextId(CONTEXT_ID_EDEFAULT);
-                return;
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                setExpression((Expression)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
+				setContextId(CONTEXT_ID_EDEFAULT);
+				return;
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				setExpression((Expression)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
-                return CONTEXT_ID_EDEFAULT == null ? contextId != null : !CONTEXT_ID_EDEFAULT.equals(contextId);
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                return expression != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
+				return CONTEXT_ID_EDEFAULT == null ? contextId != null : !CONTEXT_ID_EDEFAULT.equals(contextId);
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				return expression != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (contextId: ");
-        result.append(contextId);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (contextId: ");
+		result.append(contextId);
+		result.append(')');
+		return result.toString();
+	}
     
     @Override
     public void retrieveFeatureIds(Set<String> ids) {

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ExpressionImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ExpressionImpl.java
@@ -17,30 +17,28 @@ import cz.zcu.yafmt.model.fc.Selection;
  * <!-- begin-user-doc -->
  * An implementation of the model object '<em><b>Expression</b></em>'.
  * <!-- end-user-doc -->
- * <p>
- * </p>
  *
  * @generated
  */
 public abstract class ExpressionImpl extends MinimalEObjectImpl.Container implements Expression {
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ExpressionImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return ModelPackage.Literals.EXPRESSION;
-    }
+		return ModelPackage.Literals.EXPRESSION;
+	}
     
     public List<Selection> getSelections(FeatureConfiguration featureConfig, Selection context, String id) {
         List<Selection> allSelections = featureConfig.getSelectionsById(id);

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ForAllContextualExpressionImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ForAllContextualExpressionImpl.java
@@ -26,225 +26,225 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl#getContextId <em>Context Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.ForAllContextualExpressionImpl#getExpression <em>Expression</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class ForAllContextualExpressionImpl extends ExpressionImpl implements ForAllContextualExpression {
     /**
-     * The default value of the '{@link #getContextId() <em>Context Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getContextId() <em>Context Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getContextId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getContextId()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String CONTEXT_ID_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getContextId() <em>Context Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getContextId() <em>Context Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getContextId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getContextId()
+	 * @generated
+	 * @ordered
+	 */
     protected String contextId = CONTEXT_ID_EDEFAULT;
 
     /**
-     * The cached value of the '{@link #getExpression() <em>Expression</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getExpression() <em>Expression</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getExpression()
-     * @generated
-     * @ordered
-     */
+	 * @see #getExpression()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression expression;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ForAllContextualExpressionImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return ModelPackage.Literals.FOR_ALL_CONTEXTUAL_EXPRESSION;
-    }
+		return ModelPackage.Literals.FOR_ALL_CONTEXTUAL_EXPRESSION;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getContextId() {
-        return contextId;
-    }
+		return contextId;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setContextId(String newContextId) {
-        String oldContextId = contextId;
-        contextId = newContextId;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID, oldContextId, contextId));
-    }
+		String oldContextId = contextId;
+		contextId = newContextId;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID, oldContextId, contextId));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Expression getExpression() {
-        return expression;
-    }
+		return expression;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetExpression(Expression newExpression, NotificationChain msgs) {
-        Expression oldExpression = expression;
-        expression = newExpression;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION, oldExpression, newExpression);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldExpression = expression;
+		expression = newExpression;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION, oldExpression, newExpression);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setExpression(Expression newExpression) {
-        if (newExpression != expression) {
-            NotificationChain msgs = null;
-            if (expression != null)
-                msgs = ((InternalEObject)expression).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION, null, msgs);
-            if (newExpression != null)
-                msgs = ((InternalEObject)newExpression).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION, null, msgs);
-            msgs = basicSetExpression(newExpression, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION, newExpression, newExpression));
-    }
+		if (newExpression != expression) {
+			NotificationChain msgs = null;
+			if (expression != null)
+				msgs = ((InternalEObject)expression).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION, null, msgs);
+			if (newExpression != null)
+				msgs = ((InternalEObject)newExpression).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION, null, msgs);
+			msgs = basicSetExpression(newExpression, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION, newExpression, newExpression));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                return basicSetExpression(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				return basicSetExpression(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
-                return getContextId();
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                return getExpression();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
+				return getContextId();
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				return getExpression();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
-                setContextId((String)newValue);
-                return;
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                setExpression((Expression)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
+				setContextId((String)newValue);
+				return;
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				setExpression((Expression)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
-                setContextId(CONTEXT_ID_EDEFAULT);
-                return;
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                setExpression((Expression)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
+				setContextId(CONTEXT_ID_EDEFAULT);
+				return;
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				setExpression((Expression)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
-                return CONTEXT_ID_EDEFAULT == null ? contextId != null : !CONTEXT_ID_EDEFAULT.equals(contextId);
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
-                return expression != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID:
+				return CONTEXT_ID_EDEFAULT == null ? contextId != null : !CONTEXT_ID_EDEFAULT.equals(contextId);
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION:
+				return expression != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (contextId: ");
-        result.append(contextId);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (contextId: ");
+		result.append(contextId);
+		result.append(')');
+		return result.toString();
+	}
     
     @Override
     public void retrieveFeatureIds(Set<String> ids) {

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ImplicationImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ImplicationImpl.java
@@ -25,223 +25,223 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl#getLeftPart <em>Left Part</em>}</li>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.ImplicationImpl#getRightPart <em>Right Part</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class ImplicationImpl extends ExpressionImpl implements Implication {
     /**
-     * The cached value of the '{@link #getLeftPart() <em>Left Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getLeftPart() <em>Left Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getLeftPart()
-     * @generated
-     * @ordered
-     */
+	 * @see #getLeftPart()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression leftPart;
 
     /**
-     * The cached value of the '{@link #getRightPart() <em>Right Part</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getRightPart() <em>Right Part</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getRightPart()
-     * @generated
-     * @ordered
-     */
+	 * @see #getRightPart()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression rightPart;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ImplicationImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return ModelPackage.Literals.IMPLICATION;
-    }
+		return ModelPackage.Literals.IMPLICATION;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Expression getLeftPart() {
-        return leftPart;
-    }
+		return leftPart;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetLeftPart(Expression newLeftPart, NotificationChain msgs) {
-        Expression oldLeftPart = leftPart;
-        leftPart = newLeftPart;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.IMPLICATION__LEFT_PART, oldLeftPart, newLeftPart);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldLeftPart = leftPart;
+		leftPart = newLeftPart;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.IMPLICATION__LEFT_PART, oldLeftPart, newLeftPart);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setLeftPart(Expression newLeftPart) {
-        if (newLeftPart != leftPart) {
-            NotificationChain msgs = null;
-            if (leftPart != null)
-                msgs = ((InternalEObject)leftPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.IMPLICATION__LEFT_PART, null, msgs);
-            if (newLeftPart != null)
-                msgs = ((InternalEObject)newLeftPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.IMPLICATION__LEFT_PART, null, msgs);
-            msgs = basicSetLeftPart(newLeftPart, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.IMPLICATION__LEFT_PART, newLeftPart, newLeftPart));
-    }
+		if (newLeftPart != leftPart) {
+			NotificationChain msgs = null;
+			if (leftPart != null)
+				msgs = ((InternalEObject)leftPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.IMPLICATION__LEFT_PART, null, msgs);
+			if (newLeftPart != null)
+				msgs = ((InternalEObject)newLeftPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.IMPLICATION__LEFT_PART, null, msgs);
+			msgs = basicSetLeftPart(newLeftPart, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.IMPLICATION__LEFT_PART, newLeftPart, newLeftPart));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Expression getRightPart() {
-        return rightPart;
-    }
+		return rightPart;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetRightPart(Expression newRightPart, NotificationChain msgs) {
-        Expression oldRightPart = rightPart;
-        rightPart = newRightPart;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.IMPLICATION__RIGHT_PART, oldRightPart, newRightPart);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldRightPart = rightPart;
+		rightPart = newRightPart;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.IMPLICATION__RIGHT_PART, oldRightPart, newRightPart);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setRightPart(Expression newRightPart) {
-        if (newRightPart != rightPart) {
-            NotificationChain msgs = null;
-            if (rightPart != null)
-                msgs = ((InternalEObject)rightPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.IMPLICATION__RIGHT_PART, null, msgs);
-            if (newRightPart != null)
-                msgs = ((InternalEObject)newRightPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.IMPLICATION__RIGHT_PART, null, msgs);
-            msgs = basicSetRightPart(newRightPart, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.IMPLICATION__RIGHT_PART, newRightPart, newRightPart));
-    }
+		if (newRightPart != rightPart) {
+			NotificationChain msgs = null;
+			if (rightPart != null)
+				msgs = ((InternalEObject)rightPart).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.IMPLICATION__RIGHT_PART, null, msgs);
+			if (newRightPart != null)
+				msgs = ((InternalEObject)newRightPart).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.IMPLICATION__RIGHT_PART, null, msgs);
+			msgs = basicSetRightPart(newRightPart, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.IMPLICATION__RIGHT_PART, newRightPart, newRightPart));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case ModelPackage.IMPLICATION__LEFT_PART:
-                return basicSetLeftPart(null, msgs);
-            case ModelPackage.IMPLICATION__RIGHT_PART:
-                return basicSetRightPart(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case ModelPackage.IMPLICATION__LEFT_PART:
+				return basicSetLeftPart(null, msgs);
+			case ModelPackage.IMPLICATION__RIGHT_PART:
+				return basicSetRightPart(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case ModelPackage.IMPLICATION__LEFT_PART:
-                return getLeftPart();
-            case ModelPackage.IMPLICATION__RIGHT_PART:
-                return getRightPart();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case ModelPackage.IMPLICATION__LEFT_PART:
+				return getLeftPart();
+			case ModelPackage.IMPLICATION__RIGHT_PART:
+				return getRightPart();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case ModelPackage.IMPLICATION__LEFT_PART:
-                setLeftPart((Expression)newValue);
-                return;
-            case ModelPackage.IMPLICATION__RIGHT_PART:
-                setRightPart((Expression)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case ModelPackage.IMPLICATION__LEFT_PART:
+				setLeftPart((Expression)newValue);
+				return;
+			case ModelPackage.IMPLICATION__RIGHT_PART:
+				setRightPart((Expression)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case ModelPackage.IMPLICATION__LEFT_PART:
-                setLeftPart((Expression)null);
-                return;
-            case ModelPackage.IMPLICATION__RIGHT_PART:
-                setRightPart((Expression)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.IMPLICATION__LEFT_PART:
+				setLeftPart((Expression)null);
+				return;
+			case ModelPackage.IMPLICATION__RIGHT_PART:
+				setRightPart((Expression)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case ModelPackage.IMPLICATION__LEFT_PART:
-                return leftPart != null;
-            case ModelPackage.IMPLICATION__RIGHT_PART:
-                return rightPart != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.IMPLICATION__LEFT_PART:
+				return leftPart != null;
+			case ModelPackage.IMPLICATION__RIGHT_PART:
+				return rightPart != null;
+		}
+		return super.eIsSet(featureID);
+	}
     
     @Override
     public void retrieveFeatureIds(Set<String> ids) {

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ModelFactoryImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ModelFactoryImpl.java
@@ -20,153 +20,153 @@ import org.eclipse.emf.ecore.plugin.EcorePlugin;
  */
 public class ModelFactoryImpl extends EFactoryImpl implements ModelFactory {
     /**
-     * Creates the default factory implementation.
-     * <!-- begin-user-doc -->
+	 * Creates the default factory implementation.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public static ModelFactory init() {
-        try {
-            ModelFactory theModelFactory = (ModelFactory)EPackage.Registry.INSTANCE.getEFactory("http://zcu.cz/yafmt/clang/bcl"); 
-            if (theModelFactory != null) {
-                return theModelFactory;
-            }
-        }
-        catch (Exception exception) {
-            EcorePlugin.INSTANCE.log(exception);
-        }
-        return new ModelFactoryImpl();
-    }
+		try {
+			ModelFactory theModelFactory = (ModelFactory)EPackage.Registry.INSTANCE.getEFactory(ModelPackage.eNS_URI);
+			if (theModelFactory != null) {
+				return theModelFactory;
+			}
+		}
+		catch (Exception exception) {
+			EcorePlugin.INSTANCE.log(exception);
+		}
+		return new ModelFactoryImpl();
+	}
 
     /**
-     * Creates an instance of the factory.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ModelFactoryImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public EObject create(EClass eClass) {
-        switch (eClass.getClassifierID()) {
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION: return createForAllContextualExpression();
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION: return createExistsContextualExpression();
-            case ModelPackage.EQUATION: return createEquation();
-            case ModelPackage.IMPLICATION: return createImplication();
-            case ModelPackage.DISJUNCTION: return createDisjunction();
-            case ModelPackage.CONJUNCTION: return createConjunction();
-            case ModelPackage.NEGATION: return createNegation();
-            case ModelPackage.PRIMARY_EXPRESSION: return createPrimaryExpression();
-            default:
-                throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
-        }
-    }
+		switch (eClass.getClassifierID()) {
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION: return createForAllContextualExpression();
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION: return createExistsContextualExpression();
+			case ModelPackage.EQUATION: return createEquation();
+			case ModelPackage.IMPLICATION: return createImplication();
+			case ModelPackage.DISJUNCTION: return createDisjunction();
+			case ModelPackage.CONJUNCTION: return createConjunction();
+			case ModelPackage.NEGATION: return createNegation();
+			case ModelPackage.PRIMARY_EXPRESSION: return createPrimaryExpression();
+			default:
+				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
+		}
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ForAllContextualExpression createForAllContextualExpression() {
-        ForAllContextualExpressionImpl forAllContextualExpression = new ForAllContextualExpressionImpl();
-        return forAllContextualExpression;
-    }
+		ForAllContextualExpressionImpl forAllContextualExpression = new ForAllContextualExpressionImpl();
+		return forAllContextualExpression;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ExistsContextualExpression createExistsContextualExpression() {
-        ExistsContextualExpressionImpl existsContextualExpression = new ExistsContextualExpressionImpl();
-        return existsContextualExpression;
-    }
+		ExistsContextualExpressionImpl existsContextualExpression = new ExistsContextualExpressionImpl();
+		return existsContextualExpression;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Equation createEquation() {
-        EquationImpl equation = new EquationImpl();
-        return equation;
-    }
+		EquationImpl equation = new EquationImpl();
+		return equation;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Implication createImplication() {
-        ImplicationImpl implication = new ImplicationImpl();
-        return implication;
-    }
+		ImplicationImpl implication = new ImplicationImpl();
+		return implication;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Disjunction createDisjunction() {
-        DisjunctionImpl disjunction = new DisjunctionImpl();
-        return disjunction;
-    }
+		DisjunctionImpl disjunction = new DisjunctionImpl();
+		return disjunction;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Conjunction createConjunction() {
-        ConjunctionImpl conjunction = new ConjunctionImpl();
-        return conjunction;
-    }
+		ConjunctionImpl conjunction = new ConjunctionImpl();
+		return conjunction;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Negation createNegation() {
-        NegationImpl negation = new NegationImpl();
-        return negation;
-    }
+		NegationImpl negation = new NegationImpl();
+		return negation;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public PrimaryExpression createPrimaryExpression() {
-        PrimaryExpressionImpl primaryExpression = new PrimaryExpressionImpl();
-        return primaryExpression;
-    }
+		PrimaryExpressionImpl primaryExpression = new PrimaryExpressionImpl();
+		return primaryExpression;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ModelPackage getModelPackage() {
-        return (ModelPackage)getEPackage();
-    }
+		return (ModelPackage)getEPackage();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @deprecated
-     * @generated
-     */
+	 * @deprecated
+	 * @generated
+	 */
     @Deprecated
     public static ModelPackage getPackage() {
-        return ModelPackage.eINSTANCE;
-    }
+		return ModelPackage.eINSTANCE;
+	}
 
 } //ModelFactoryImpl

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ModelPackageImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/ModelPackageImpl.java
@@ -28,469 +28,469 @@ import cz.zcu.yafmt.clang.bcl.model.PrimaryExpression;
  */
 public class ModelPackageImpl extends EPackageImpl implements ModelPackage {
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass expressionEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass forAllContextualExpressionEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass existsContextualExpressionEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass equationEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass implicationEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass disjunctionEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass conjunctionEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass negationEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass primaryExpressionEClass = null;
 
     /**
-     * Creates an instance of the model <b>Package</b>, registered with
-     * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-     * package URI value.
-     * <p>Note: the correct way to create the package is via the static
-     * factory method {@link #init init()}, which also performs
-     * initialization of the package, or returns the registered package,
-     * if one already exists.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the model <b>Package</b>, registered with
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
+	 * package URI value.
+	 * <p>Note: the correct way to create the package is via the static
+	 * factory method {@link #init init()}, which also performs
+	 * initialization of the package, or returns the registered package,
+	 * if one already exists.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see org.eclipse.emf.ecore.EPackage.Registry
-     * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#eNS_URI
-     * @see #init()
-     * @generated
-     */
+	 * @see org.eclipse.emf.ecore.EPackage.Registry
+	 * @see cz.zcu.yafmt.clang.bcl.model.ModelPackage#eNS_URI
+	 * @see #init()
+	 * @generated
+	 */
     private ModelPackageImpl() {
-        super(eNS_URI, ModelFactory.eINSTANCE);
-    }
+		super(eNS_URI, ModelFactory.eINSTANCE);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private static boolean isInited = false;
 
     /**
-     * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-     * 
-     * <p>This method is used to initialize {@link ModelPackage#eINSTANCE} when that field is accessed.
-     * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-     * <!-- begin-user-doc -->
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * 
+	 * <p>This method is used to initialize {@link ModelPackage#eINSTANCE} when that field is accessed.
+	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #eNS_URI
-     * @see #createPackageContents()
-     * @see #initializePackageContents()
-     * @generated
-     */
+	 * @see #eNS_URI
+	 * @see #createPackageContents()
+	 * @see #initializePackageContents()
+	 * @generated
+	 */
     public static ModelPackage init() {
-        if (isInited) return (ModelPackage)EPackage.Registry.INSTANCE.getEPackage(ModelPackage.eNS_URI);
+		if (isInited) return (ModelPackage)EPackage.Registry.INSTANCE.getEPackage(ModelPackage.eNS_URI);
 
-        // Obtain or create and register package
-        ModelPackageImpl theModelPackage = (ModelPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof ModelPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new ModelPackageImpl());
+		// Obtain or create and register package
+		ModelPackageImpl theModelPackage = (ModelPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof ModelPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new ModelPackageImpl());
 
-        isInited = true;
+		isInited = true;
 
-        // Create package meta-data objects
-        theModelPackage.createPackageContents();
+		// Create package meta-data objects
+		theModelPackage.createPackageContents();
 
-        // Initialize created meta-data
-        theModelPackage.initializePackageContents();
+		// Initialize created meta-data
+		theModelPackage.initializePackageContents();
 
-        // Mark meta-data to indicate it can't be changed
-        theModelPackage.freeze();
+		// Mark meta-data to indicate it can't be changed
+		theModelPackage.freeze();
 
   
-        // Update the registry and return the package
-        EPackage.Registry.INSTANCE.put(ModelPackage.eNS_URI, theModelPackage);
-        return theModelPackage;
-    }
+		// Update the registry and return the package
+		EPackage.Registry.INSTANCE.put(ModelPackage.eNS_URI, theModelPackage);
+		return theModelPackage;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getExpression() {
-        return expressionEClass;
-    }
+		return expressionEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getForAllContextualExpression() {
-        return forAllContextualExpressionEClass;
-    }
+		return forAllContextualExpressionEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getForAllContextualExpression_ContextId() {
-        return (EAttribute)forAllContextualExpressionEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)forAllContextualExpressionEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getForAllContextualExpression_Expression() {
-        return (EReference)forAllContextualExpressionEClass.getEStructuralFeatures().get(1);
-    }
+		return (EReference)forAllContextualExpressionEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getExistsContextualExpression() {
-        return existsContextualExpressionEClass;
-    }
+		return existsContextualExpressionEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getExistsContextualExpression_ContextId() {
-        return (EAttribute)existsContextualExpressionEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)existsContextualExpressionEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getExistsContextualExpression_Expression() {
-        return (EReference)existsContextualExpressionEClass.getEStructuralFeatures().get(1);
-    }
+		return (EReference)existsContextualExpressionEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getEquation() {
-        return equationEClass;
-    }
+		return equationEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getEquation_LeftPart() {
-        return (EReference)equationEClass.getEStructuralFeatures().get(0);
-    }
+		return (EReference)equationEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getEquation_RightPart() {
-        return (EReference)equationEClass.getEStructuralFeatures().get(1);
-    }
+		return (EReference)equationEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getImplication() {
-        return implicationEClass;
-    }
+		return implicationEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getImplication_LeftPart() {
-        return (EReference)implicationEClass.getEStructuralFeatures().get(0);
-    }
+		return (EReference)implicationEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getImplication_RightPart() {
-        return (EReference)implicationEClass.getEStructuralFeatures().get(1);
-    }
+		return (EReference)implicationEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getDisjunction() {
-        return disjunctionEClass;
-    }
+		return disjunctionEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getDisjunction_LeftPart() {
-        return (EReference)disjunctionEClass.getEStructuralFeatures().get(0);
-    }
+		return (EReference)disjunctionEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getDisjunction_RightPart() {
-        return (EReference)disjunctionEClass.getEStructuralFeatures().get(1);
-    }
+		return (EReference)disjunctionEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getConjunction() {
-        return conjunctionEClass;
-    }
+		return conjunctionEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getConjunction_LeftPart() {
-        return (EReference)conjunctionEClass.getEStructuralFeatures().get(0);
-    }
+		return (EReference)conjunctionEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getConjunction_RightPart() {
-        return (EReference)conjunctionEClass.getEStructuralFeatures().get(1);
-    }
+		return (EReference)conjunctionEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getNegation() {
-        return negationEClass;
-    }
+		return negationEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getNegation_Expression() {
-        return (EReference)negationEClass.getEStructuralFeatures().get(0);
-    }
+		return (EReference)negationEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getPrimaryExpression() {
-        return primaryExpressionEClass;
-    }
+		return primaryExpressionEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getPrimaryExpression_FeatureId() {
-        return (EAttribute)primaryExpressionEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)primaryExpressionEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ModelFactory getModelFactory() {
-        return (ModelFactory)getEFactoryInstance();
-    }
+		return (ModelFactory)getEFactoryInstance();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private boolean isCreated = false;
 
     /**
-     * Creates the meta-model objects for the package.  This method is
-     * guarded to have no affect on any invocation but its first.
-     * <!-- begin-user-doc -->
+	 * Creates the meta-model objects for the package.  This method is
+	 * guarded to have no affect on any invocation but its first.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void createPackageContents() {
-        if (isCreated) return;
-        isCreated = true;
+		if (isCreated) return;
+		isCreated = true;
 
-        // Create classes and their features
-        expressionEClass = createEClass(EXPRESSION);
+		// Create classes and their features
+		expressionEClass = createEClass(EXPRESSION);
 
-        forAllContextualExpressionEClass = createEClass(FOR_ALL_CONTEXTUAL_EXPRESSION);
-        createEAttribute(forAllContextualExpressionEClass, FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID);
-        createEReference(forAllContextualExpressionEClass, FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION);
+		forAllContextualExpressionEClass = createEClass(FOR_ALL_CONTEXTUAL_EXPRESSION);
+		createEAttribute(forAllContextualExpressionEClass, FOR_ALL_CONTEXTUAL_EXPRESSION__CONTEXT_ID);
+		createEReference(forAllContextualExpressionEClass, FOR_ALL_CONTEXTUAL_EXPRESSION__EXPRESSION);
 
-        existsContextualExpressionEClass = createEClass(EXISTS_CONTEXTUAL_EXPRESSION);
-        createEAttribute(existsContextualExpressionEClass, EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID);
-        createEReference(existsContextualExpressionEClass, EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION);
+		existsContextualExpressionEClass = createEClass(EXISTS_CONTEXTUAL_EXPRESSION);
+		createEAttribute(existsContextualExpressionEClass, EXISTS_CONTEXTUAL_EXPRESSION__CONTEXT_ID);
+		createEReference(existsContextualExpressionEClass, EXISTS_CONTEXTUAL_EXPRESSION__EXPRESSION);
 
-        equationEClass = createEClass(EQUATION);
-        createEReference(equationEClass, EQUATION__LEFT_PART);
-        createEReference(equationEClass, EQUATION__RIGHT_PART);
+		equationEClass = createEClass(EQUATION);
+		createEReference(equationEClass, EQUATION__LEFT_PART);
+		createEReference(equationEClass, EQUATION__RIGHT_PART);
 
-        implicationEClass = createEClass(IMPLICATION);
-        createEReference(implicationEClass, IMPLICATION__LEFT_PART);
-        createEReference(implicationEClass, IMPLICATION__RIGHT_PART);
+		implicationEClass = createEClass(IMPLICATION);
+		createEReference(implicationEClass, IMPLICATION__LEFT_PART);
+		createEReference(implicationEClass, IMPLICATION__RIGHT_PART);
 
-        disjunctionEClass = createEClass(DISJUNCTION);
-        createEReference(disjunctionEClass, DISJUNCTION__LEFT_PART);
-        createEReference(disjunctionEClass, DISJUNCTION__RIGHT_PART);
+		disjunctionEClass = createEClass(DISJUNCTION);
+		createEReference(disjunctionEClass, DISJUNCTION__LEFT_PART);
+		createEReference(disjunctionEClass, DISJUNCTION__RIGHT_PART);
 
-        conjunctionEClass = createEClass(CONJUNCTION);
-        createEReference(conjunctionEClass, CONJUNCTION__LEFT_PART);
-        createEReference(conjunctionEClass, CONJUNCTION__RIGHT_PART);
+		conjunctionEClass = createEClass(CONJUNCTION);
+		createEReference(conjunctionEClass, CONJUNCTION__LEFT_PART);
+		createEReference(conjunctionEClass, CONJUNCTION__RIGHT_PART);
 
-        negationEClass = createEClass(NEGATION);
-        createEReference(negationEClass, NEGATION__EXPRESSION);
+		negationEClass = createEClass(NEGATION);
+		createEReference(negationEClass, NEGATION__EXPRESSION);
 
-        primaryExpressionEClass = createEClass(PRIMARY_EXPRESSION);
-        createEAttribute(primaryExpressionEClass, PRIMARY_EXPRESSION__FEATURE_ID);
-    }
+		primaryExpressionEClass = createEClass(PRIMARY_EXPRESSION);
+		createEAttribute(primaryExpressionEClass, PRIMARY_EXPRESSION__FEATURE_ID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private boolean isInitialized = false;
 
     /**
-     * Complete the initialization of the package and its meta-model.  This
-     * method is guarded to have no affect on any invocation but its first.
-     * <!-- begin-user-doc -->
+	 * Complete the initialization of the package and its meta-model.  This
+	 * method is guarded to have no affect on any invocation but its first.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void initializePackageContents() {
-        if (isInitialized) return;
-        isInitialized = true;
+		if (isInitialized) return;
+		isInitialized = true;
 
-        // Initialize package
-        setName(eNAME);
-        setNsPrefix(eNS_PREFIX);
-        setNsURI(eNS_URI);
+		// Initialize package
+		setName(eNAME);
+		setNsPrefix(eNS_PREFIX);
+		setNsURI(eNS_URI);
 
-        // Create type parameters
+		// Create type parameters
 
-        // Set bounds for type parameters
+		// Set bounds for type parameters
 
-        // Add supertypes to classes
-        forAllContextualExpressionEClass.getESuperTypes().add(this.getExpression());
-        existsContextualExpressionEClass.getESuperTypes().add(this.getExpression());
-        equationEClass.getESuperTypes().add(this.getExpression());
-        implicationEClass.getESuperTypes().add(this.getExpression());
-        disjunctionEClass.getESuperTypes().add(this.getExpression());
-        conjunctionEClass.getESuperTypes().add(this.getExpression());
-        negationEClass.getESuperTypes().add(this.getExpression());
-        primaryExpressionEClass.getESuperTypes().add(this.getExpression());
+		// Add supertypes to classes
+		forAllContextualExpressionEClass.getESuperTypes().add(this.getExpression());
+		existsContextualExpressionEClass.getESuperTypes().add(this.getExpression());
+		equationEClass.getESuperTypes().add(this.getExpression());
+		implicationEClass.getESuperTypes().add(this.getExpression());
+		disjunctionEClass.getESuperTypes().add(this.getExpression());
+		conjunctionEClass.getESuperTypes().add(this.getExpression());
+		negationEClass.getESuperTypes().add(this.getExpression());
+		primaryExpressionEClass.getESuperTypes().add(this.getExpression());
 
-        // Initialize classes and features; add operations and parameters
-        initEClass(expressionEClass, Expression.class, "Expression", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		// Initialize classes and features; add operations and parameters
+		initEClass(expressionEClass, Expression.class, "Expression", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
-        initEClass(forAllContextualExpressionEClass, ForAllContextualExpression.class, "ForAllContextualExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getForAllContextualExpression_ContextId(), ecorePackage.getEString(), "contextId", null, 0, 1, ForAllContextualExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getForAllContextualExpression_Expression(), this.getExpression(), null, "expression", null, 0, 1, ForAllContextualExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(forAllContextualExpressionEClass, ForAllContextualExpression.class, "ForAllContextualExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getForAllContextualExpression_ContextId(), ecorePackage.getEString(), "contextId", null, 0, 1, ForAllContextualExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getForAllContextualExpression_Expression(), this.getExpression(), null, "expression", null, 0, 1, ForAllContextualExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(existsContextualExpressionEClass, ExistsContextualExpression.class, "ExistsContextualExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getExistsContextualExpression_ContextId(), ecorePackage.getEString(), "contextId", null, 0, 1, ExistsContextualExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getExistsContextualExpression_Expression(), this.getExpression(), null, "expression", null, 0, 1, ExistsContextualExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(existsContextualExpressionEClass, ExistsContextualExpression.class, "ExistsContextualExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getExistsContextualExpression_ContextId(), ecorePackage.getEString(), "contextId", null, 0, 1, ExistsContextualExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getExistsContextualExpression_Expression(), this.getExpression(), null, "expression", null, 0, 1, ExistsContextualExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(equationEClass, Equation.class, "Equation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEReference(getEquation_LeftPart(), this.getExpression(), null, "leftPart", null, 0, 1, Equation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getEquation_RightPart(), this.getExpression(), null, "rightPart", null, 0, 1, Equation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(equationEClass, Equation.class, "Equation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getEquation_LeftPart(), this.getExpression(), null, "leftPart", null, 0, 1, Equation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getEquation_RightPart(), this.getExpression(), null, "rightPart", null, 0, 1, Equation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(implicationEClass, Implication.class, "Implication", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEReference(getImplication_LeftPart(), this.getExpression(), null, "leftPart", null, 0, 1, Implication.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getImplication_RightPart(), this.getExpression(), null, "rightPart", null, 0, 1, Implication.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(implicationEClass, Implication.class, "Implication", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getImplication_LeftPart(), this.getExpression(), null, "leftPart", null, 0, 1, Implication.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getImplication_RightPart(), this.getExpression(), null, "rightPart", null, 0, 1, Implication.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(disjunctionEClass, Disjunction.class, "Disjunction", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEReference(getDisjunction_LeftPart(), this.getExpression(), null, "leftPart", null, 0, 1, Disjunction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getDisjunction_RightPart(), this.getExpression(), null, "rightPart", null, 0, 1, Disjunction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(disjunctionEClass, Disjunction.class, "Disjunction", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getDisjunction_LeftPart(), this.getExpression(), null, "leftPart", null, 0, 1, Disjunction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getDisjunction_RightPart(), this.getExpression(), null, "rightPart", null, 0, 1, Disjunction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(conjunctionEClass, Conjunction.class, "Conjunction", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEReference(getConjunction_LeftPart(), this.getExpression(), null, "leftPart", null, 0, 1, Conjunction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getConjunction_RightPart(), this.getExpression(), null, "rightPart", null, 0, 1, Conjunction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(conjunctionEClass, Conjunction.class, "Conjunction", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getConjunction_LeftPart(), this.getExpression(), null, "leftPart", null, 0, 1, Conjunction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getConjunction_RightPart(), this.getExpression(), null, "rightPart", null, 0, 1, Conjunction.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(negationEClass, Negation.class, "Negation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEReference(getNegation_Expression(), this.getExpression(), null, "expression", null, 0, 1, Negation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(negationEClass, Negation.class, "Negation", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getNegation_Expression(), this.getExpression(), null, "expression", null, 0, 1, Negation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(primaryExpressionEClass, PrimaryExpression.class, "PrimaryExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getPrimaryExpression_FeatureId(), ecorePackage.getEString(), "featureId", null, 0, 1, PrimaryExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(primaryExpressionEClass, PrimaryExpression.class, "PrimaryExpression", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getPrimaryExpression_FeatureId(), ecorePackage.getEString(), "featureId", null, 0, 1, PrimaryExpression.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        // Create resource
-        createResource(eNS_URI);
-    }
+		// Create resource
+		createResource(eNS_URI);
+	}
 
 } //ModelPackageImpl

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/NegationImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/NegationImpl.java
@@ -24,157 +24,157 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.NegationImpl#getExpression <em>Expression</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class NegationImpl extends ExpressionImpl implements Negation {
     /**
-     * The cached value of the '{@link #getExpression() <em>Expression</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getExpression() <em>Expression</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getExpression()
-     * @generated
-     * @ordered
-     */
+	 * @see #getExpression()
+	 * @generated
+	 * @ordered
+	 */
     protected Expression expression;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected NegationImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return ModelPackage.Literals.NEGATION;
-    }
+		return ModelPackage.Literals.NEGATION;
+	}
     
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Expression getExpression() {
-        return expression;
-    }
+		return expression;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetExpression(Expression newExpression, NotificationChain msgs) {
-        Expression oldExpression = expression;
-        expression = newExpression;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.NEGATION__EXPRESSION, oldExpression, newExpression);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Expression oldExpression = expression;
+		expression = newExpression;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, ModelPackage.NEGATION__EXPRESSION, oldExpression, newExpression);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setExpression(Expression newExpression) {
-        if (newExpression != expression) {
-            NotificationChain msgs = null;
-            if (expression != null)
-                msgs = ((InternalEObject)expression).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.NEGATION__EXPRESSION, null, msgs);
-            if (newExpression != null)
-                msgs = ((InternalEObject)newExpression).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.NEGATION__EXPRESSION, null, msgs);
-            msgs = basicSetExpression(newExpression, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.NEGATION__EXPRESSION, newExpression, newExpression));
-    }
+		if (newExpression != expression) {
+			NotificationChain msgs = null;
+			if (expression != null)
+				msgs = ((InternalEObject)expression).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - ModelPackage.NEGATION__EXPRESSION, null, msgs);
+			if (newExpression != null)
+				msgs = ((InternalEObject)newExpression).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - ModelPackage.NEGATION__EXPRESSION, null, msgs);
+			msgs = basicSetExpression(newExpression, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.NEGATION__EXPRESSION, newExpression, newExpression));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case ModelPackage.NEGATION__EXPRESSION:
-                return basicSetExpression(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case ModelPackage.NEGATION__EXPRESSION:
+				return basicSetExpression(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case ModelPackage.NEGATION__EXPRESSION:
-                return getExpression();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case ModelPackage.NEGATION__EXPRESSION:
+				return getExpression();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case ModelPackage.NEGATION__EXPRESSION:
-                setExpression((Expression)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case ModelPackage.NEGATION__EXPRESSION:
+				setExpression((Expression)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case ModelPackage.NEGATION__EXPRESSION:
-                setExpression((Expression)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.NEGATION__EXPRESSION:
+				setExpression((Expression)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case ModelPackage.NEGATION__EXPRESSION:
-                return expression != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.NEGATION__EXPRESSION:
+				return expression != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     @Override
     public void retrieveFeatureIds(Set<String> ids) {

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/PrimaryExpressionImpl.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/impl/PrimaryExpressionImpl.java
@@ -22,147 +22,147 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.clang.bcl.model.impl.PrimaryExpressionImpl#getFeatureId <em>Feature Id</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class PrimaryExpressionImpl extends ExpressionImpl implements PrimaryExpression {
     /**
-     * The default value of the '{@link #getFeatureId() <em>Feature Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getFeatureId() <em>Feature Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getFeatureId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getFeatureId()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String FEATURE_ID_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getFeatureId() <em>Feature Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getFeatureId() <em>Feature Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getFeatureId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getFeatureId()
+	 * @generated
+	 * @ordered
+	 */
     protected String featureId = FEATURE_ID_EDEFAULT;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected PrimaryExpressionImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return ModelPackage.Literals.PRIMARY_EXPRESSION;
-    }
+		return ModelPackage.Literals.PRIMARY_EXPRESSION;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getFeatureId() {
-        return featureId;
-    }
+		return featureId;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setFeatureId(String newFeatureId) {
-        String oldFeatureId = featureId;
-        featureId = newFeatureId;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID, oldFeatureId, featureId));
-    }
+		String oldFeatureId = featureId;
+		featureId = newFeatureId;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID, oldFeatureId, featureId));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID:
-                return getFeatureId();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID:
+				return getFeatureId();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID:
-                setFeatureId((String)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID:
+				setFeatureId((String)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID:
-                setFeatureId(FEATURE_ID_EDEFAULT);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID:
+				setFeatureId(FEATURE_ID_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID:
-                return FEATURE_ID_EDEFAULT == null ? featureId != null : !FEATURE_ID_EDEFAULT.equals(featureId);
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case ModelPackage.PRIMARY_EXPRESSION__FEATURE_ID:
+				return FEATURE_ID_EDEFAULT == null ? featureId != null : !FEATURE_ID_EDEFAULT.equals(featureId);
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (featureId: ");
-        result.append(featureId);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (featureId: ");
+		result.append(featureId);
+		result.append(')');
+		return result.toString();
+	}
     
     @Override
     public void retrieveFeatureIds(Set<String> ids) {

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/util/ModelAdapterFactory.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/util/ModelAdapterFactory.java
@@ -21,244 +21,244 @@ import org.eclipse.emf.ecore.EObject;
  */
 public class ModelAdapterFactory extends AdapterFactoryImpl {
     /**
-     * The cached model package.
-     * <!-- begin-user-doc -->
+	 * The cached model package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected static ModelPackage modelPackage;
 
     /**
-     * Creates an instance of the adapter factory.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the adapter factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ModelAdapterFactory() {
-        if (modelPackage == null) {
-            modelPackage = ModelPackage.eINSTANCE;
-        }
-    }
+		if (modelPackage == null) {
+			modelPackage = ModelPackage.eINSTANCE;
+		}
+	}
 
     /**
-     * Returns whether this factory is applicable for the type of the object.
-     * <!-- begin-user-doc -->
+	 * Returns whether this factory is applicable for the type of the object.
+	 * <!-- begin-user-doc -->
      * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
      * <!-- end-user-doc -->
-     * @return whether this factory is applicable for the type of the object.
-     * @generated
-     */
+	 * @return whether this factory is applicable for the type of the object.
+	 * @generated
+	 */
     @Override
     public boolean isFactoryForType(Object object) {
-        if (object == modelPackage) {
-            return true;
-        }
-        if (object instanceof EObject) {
-            return ((EObject)object).eClass().getEPackage() == modelPackage;
-        }
-        return false;
-    }
+		if (object == modelPackage) {
+			return true;
+		}
+		if (object instanceof EObject) {
+			return ((EObject)object).eClass().getEPackage() == modelPackage;
+		}
+		return false;
+	}
 
     /**
-     * The switch that delegates to the <code>createXXX</code> methods.
-     * <!-- begin-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ModelSwitch<Adapter> modelSwitch =
         new ModelSwitch<Adapter>() {
-            @Override
-            public Adapter caseExpression(Expression object) {
-                return createExpressionAdapter();
-            }
-            @Override
-            public Adapter caseForAllContextualExpression(ForAllContextualExpression object) {
-                return createForAllContextualExpressionAdapter();
-            }
-            @Override
-            public Adapter caseExistsContextualExpression(ExistsContextualExpression object) {
-                return createExistsContextualExpressionAdapter();
-            }
-            @Override
-            public Adapter caseEquation(Equation object) {
-                return createEquationAdapter();
-            }
-            @Override
-            public Adapter caseImplication(Implication object) {
-                return createImplicationAdapter();
-            }
-            @Override
-            public Adapter caseDisjunction(Disjunction object) {
-                return createDisjunctionAdapter();
-            }
-            @Override
-            public Adapter caseConjunction(Conjunction object) {
-                return createConjunctionAdapter();
-            }
-            @Override
-            public Adapter caseNegation(Negation object) {
-                return createNegationAdapter();
-            }
-            @Override
-            public Adapter casePrimaryExpression(PrimaryExpression object) {
-                return createPrimaryExpressionAdapter();
-            }
-            @Override
-            public Adapter defaultCase(EObject object) {
-                return createEObjectAdapter();
-            }
-        };
+			@Override
+			public Adapter caseExpression(Expression object) {
+				return createExpressionAdapter();
+			}
+			@Override
+			public Adapter caseForAllContextualExpression(ForAllContextualExpression object) {
+				return createForAllContextualExpressionAdapter();
+			}
+			@Override
+			public Adapter caseExistsContextualExpression(ExistsContextualExpression object) {
+				return createExistsContextualExpressionAdapter();
+			}
+			@Override
+			public Adapter caseEquation(Equation object) {
+				return createEquationAdapter();
+			}
+			@Override
+			public Adapter caseImplication(Implication object) {
+				return createImplicationAdapter();
+			}
+			@Override
+			public Adapter caseDisjunction(Disjunction object) {
+				return createDisjunctionAdapter();
+			}
+			@Override
+			public Adapter caseConjunction(Conjunction object) {
+				return createConjunctionAdapter();
+			}
+			@Override
+			public Adapter caseNegation(Negation object) {
+				return createNegationAdapter();
+			}
+			@Override
+			public Adapter casePrimaryExpression(PrimaryExpression object) {
+				return createPrimaryExpressionAdapter();
+			}
+			@Override
+			public Adapter defaultCase(EObject object) {
+				return createEObjectAdapter();
+			}
+		};
 
     /**
-     * Creates an adapter for the <code>target</code>.
-     * <!-- begin-user-doc -->
+	 * Creates an adapter for the <code>target</code>.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param target the object to adapt.
-     * @return the adapter for the <code>target</code>.
-     * @generated
-     */
+	 * @param target the object to adapt.
+	 * @return the adapter for the <code>target</code>.
+	 * @generated
+	 */
     @Override
     public Adapter createAdapter(Notifier target) {
-        return modelSwitch.doSwitch((EObject)target);
-    }
+		return modelSwitch.doSwitch((EObject)target);
+	}
 
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Expression <em>Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Expression <em>Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.clang.bcl.model.Expression
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Expression
+	 * @generated
+	 */
     public Adapter createExpressionAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression <em>For All Contextual Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression <em>For All Contextual Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.clang.bcl.model.ForAllContextualExpression
+	 * @generated
+	 */
     public Adapter createForAllContextualExpressionAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression <em>Exists Contextual Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression <em>Exists Contextual Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.clang.bcl.model.ExistsContextualExpression
+	 * @generated
+	 */
     public Adapter createExistsContextualExpressionAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Equation <em>Equation</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Equation <em>Equation</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.clang.bcl.model.Equation
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Equation
+	 * @generated
+	 */
     public Adapter createEquationAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Implication <em>Implication</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Implication <em>Implication</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.clang.bcl.model.Implication
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Implication
+	 * @generated
+	 */
     public Adapter createImplicationAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction <em>Disjunction</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Disjunction <em>Disjunction</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.clang.bcl.model.Disjunction
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Disjunction
+	 * @generated
+	 */
     public Adapter createDisjunctionAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction <em>Conjunction</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Conjunction <em>Conjunction</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.clang.bcl.model.Conjunction
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Conjunction
+	 * @generated
+	 */
     public Adapter createConjunctionAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Negation <em>Negation</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.Negation <em>Negation</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.clang.bcl.model.Negation
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.clang.bcl.model.Negation
+	 * @generated
+	 */
     public Adapter createNegationAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.PrimaryExpression <em>Primary Expression</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.clang.bcl.model.PrimaryExpression <em>Primary Expression</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.clang.bcl.model.PrimaryExpression
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.clang.bcl.model.PrimaryExpression
+	 * @generated
+	 */
     public Adapter createPrimaryExpressionAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for the default case.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for the default case.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @generated
+	 */
     public Adapter createEObjectAdapter() {
-        return null;
-    }
+		return null;
+	}
 
 } //ModelAdapterFactory

--- a/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/util/ModelSwitch.java
+++ b/cz.zcu.yafmt.clang.bcl/src/cz/zcu/yafmt/clang/bcl/model/util/ModelSwitch.java
@@ -24,263 +24,263 @@ import org.eclipse.emf.ecore.util.Switch;
  */
 public class ModelSwitch<T> extends Switch<T> {
     /**
-     * The cached model package
-     * <!-- begin-user-doc -->
+	 * The cached model package
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected static ModelPackage modelPackage;
 
     /**
-     * Creates an instance of the switch.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the switch.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ModelSwitch() {
-        if (modelPackage == null) {
-            modelPackage = ModelPackage.eINSTANCE;
-        }
-    }
+		if (modelPackage == null) {
+			modelPackage = ModelPackage.eINSTANCE;
+		}
+	}
 
     /**
-     * Checks whether this is a switch for the given package.
-     * <!-- begin-user-doc -->
+	 * Checks whether this is a switch for the given package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @parameter ePackage the package in question.
-     * @return whether this is a switch for the given package.
-     * @generated
-     */
+	 * @param ePackage the package in question.
+	 * @return whether this is a switch for the given package.
+	 * @generated
+	 */
     @Override
     protected boolean isSwitchFor(EPackage ePackage) {
-        return ePackage == modelPackage;
-    }
+		return ePackage == modelPackage;
+	}
 
     /**
-     * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-     * <!-- begin-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the first non-null result returned by a <code>caseXXX</code> call.
-     * @generated
-     */
+	 * @return the first non-null result returned by a <code>caseXXX</code> call.
+	 * @generated
+	 */
     @Override
     protected T doSwitch(int classifierID, EObject theEObject) {
-        switch (classifierID) {
-            case ModelPackage.EXPRESSION: {
-                Expression expression = (Expression)theEObject;
-                T result = caseExpression(expression);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION: {
-                ForAllContextualExpression forAllContextualExpression = (ForAllContextualExpression)theEObject;
-                T result = caseForAllContextualExpression(forAllContextualExpression);
-                if (result == null) result = caseExpression(forAllContextualExpression);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION: {
-                ExistsContextualExpression existsContextualExpression = (ExistsContextualExpression)theEObject;
-                T result = caseExistsContextualExpression(existsContextualExpression);
-                if (result == null) result = caseExpression(existsContextualExpression);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case ModelPackage.EQUATION: {
-                Equation equation = (Equation)theEObject;
-                T result = caseEquation(equation);
-                if (result == null) result = caseExpression(equation);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case ModelPackage.IMPLICATION: {
-                Implication implication = (Implication)theEObject;
-                T result = caseImplication(implication);
-                if (result == null) result = caseExpression(implication);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case ModelPackage.DISJUNCTION: {
-                Disjunction disjunction = (Disjunction)theEObject;
-                T result = caseDisjunction(disjunction);
-                if (result == null) result = caseExpression(disjunction);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case ModelPackage.CONJUNCTION: {
-                Conjunction conjunction = (Conjunction)theEObject;
-                T result = caseConjunction(conjunction);
-                if (result == null) result = caseExpression(conjunction);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case ModelPackage.NEGATION: {
-                Negation negation = (Negation)theEObject;
-                T result = caseNegation(negation);
-                if (result == null) result = caseExpression(negation);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case ModelPackage.PRIMARY_EXPRESSION: {
-                PrimaryExpression primaryExpression = (PrimaryExpression)theEObject;
-                T result = casePrimaryExpression(primaryExpression);
-                if (result == null) result = caseExpression(primaryExpression);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            default: return defaultCase(theEObject);
-        }
-    }
+		switch (classifierID) {
+			case ModelPackage.EXPRESSION: {
+				Expression expression = (Expression)theEObject;
+				T result = caseExpression(expression);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case ModelPackage.FOR_ALL_CONTEXTUAL_EXPRESSION: {
+				ForAllContextualExpression forAllContextualExpression = (ForAllContextualExpression)theEObject;
+				T result = caseForAllContextualExpression(forAllContextualExpression);
+				if (result == null) result = caseExpression(forAllContextualExpression);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case ModelPackage.EXISTS_CONTEXTUAL_EXPRESSION: {
+				ExistsContextualExpression existsContextualExpression = (ExistsContextualExpression)theEObject;
+				T result = caseExistsContextualExpression(existsContextualExpression);
+				if (result == null) result = caseExpression(existsContextualExpression);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case ModelPackage.EQUATION: {
+				Equation equation = (Equation)theEObject;
+				T result = caseEquation(equation);
+				if (result == null) result = caseExpression(equation);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case ModelPackage.IMPLICATION: {
+				Implication implication = (Implication)theEObject;
+				T result = caseImplication(implication);
+				if (result == null) result = caseExpression(implication);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case ModelPackage.DISJUNCTION: {
+				Disjunction disjunction = (Disjunction)theEObject;
+				T result = caseDisjunction(disjunction);
+				if (result == null) result = caseExpression(disjunction);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case ModelPackage.CONJUNCTION: {
+				Conjunction conjunction = (Conjunction)theEObject;
+				T result = caseConjunction(conjunction);
+				if (result == null) result = caseExpression(conjunction);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case ModelPackage.NEGATION: {
+				Negation negation = (Negation)theEObject;
+				T result = caseNegation(negation);
+				if (result == null) result = caseExpression(negation);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case ModelPackage.PRIMARY_EXPRESSION: {
+				PrimaryExpression primaryExpression = (PrimaryExpression)theEObject;
+				T result = casePrimaryExpression(primaryExpression);
+				if (result == null) result = caseExpression(primaryExpression);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			default: return defaultCase(theEObject);
+		}
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Expression</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Expression</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Expression</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Expression</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseExpression(Expression object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>For All Contextual Expression</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>For All Contextual Expression</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>For All Contextual Expression</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>For All Contextual Expression</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseForAllContextualExpression(ForAllContextualExpression object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Exists Contextual Expression</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Exists Contextual Expression</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Exists Contextual Expression</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Exists Contextual Expression</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseExistsContextualExpression(ExistsContextualExpression object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Equation</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Equation</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Equation</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Equation</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseEquation(Equation object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Implication</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Implication</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Implication</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Implication</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseImplication(Implication object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Disjunction</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Disjunction</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Disjunction</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Disjunction</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseDisjunction(Disjunction object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Conjunction</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Conjunction</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Conjunction</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Conjunction</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseConjunction(Conjunction object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Negation</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Negation</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Negation</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Negation</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseNegation(Negation object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Primary Expression</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Primary Expression</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Primary Expression</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Primary Expression</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T casePrimaryExpression(PrimaryExpression object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch, but this is the last case anyway.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
+	 * @generated
+	 */
     @Override
     public T defaultCase(EObject object) {
-        return null;
-    }
+		return null;
+	}
 
 } //ModelSwitch

--- a/cz.zcu.yafmt.model.edit/META-INF/MANIFEST.MF
+++ b/cz.zcu.yafmt.model.edit/META-INF/MANIFEST.MF
@@ -33,7 +33,8 @@ Export-Package: cz.zcu.yafmt.model.fc.provider;
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.8.0",
  org.eclipse.emf.edit.ui;bundle-version="2.8.0",
  cz.zcu.yafmt.clang;bundle-version="0.3.0",
- cz.zcu.yafmt.model;bundle-version="0.3.0",
+ cz.zcu.yafmt.model;bundle-version="0.3.0";visibility:=reexport,
+ org.eclipse.emf.edit;visibility:=reexport,
  cz.zcu.yafmt.model.validation;bundle-version="0.3.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/cz.zcu.yafmt.model.edit/plugin.properties
+++ b/cz.zcu.yafmt.model.edit/plugin.properties
@@ -117,3 +117,4 @@ _UI_AttributeType_BOOLEAN_literal = Boolean
 _UI_AttributeType_INTEGER_literal = Integer
 _UI_AttributeType_DOUBLE_literal = Double
 _UI_AttributeType_STRING_literal = String
+_UI_Attribute_value_feature = Value

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/AttributeValueItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/AttributeValueItemProvider.java
@@ -39,14 +39,14 @@ public class AttributeValueItemProvider
         IItemLabelProvider,
         IItemPropertySource {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public AttributeValueItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
      * This returns the property descriptors for the adapted class.
@@ -74,92 +74,92 @@ public class AttributeValueItemProvider
     }
 
     /**
-     * This adds a property descriptor for the Id feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Id feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addIdPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_AttributeValue_id_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_AttributeValue_id_feature", "_UI_AttributeValue_type"),
-                 FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE__ID,
-                 false,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_AttributeValue_id_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_AttributeValue_id_feature", "_UI_AttributeValue_type"),
+				 FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE__ID,
+				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Name feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Name feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addNamePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_AttributeValue_name_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_AttributeValue_name_feature", "_UI_AttributeValue_type"),
-                 FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE__NAME,
-                 false,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_AttributeValue_name_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_AttributeValue_name_feature", "_UI_AttributeValue_type"),
+				 FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE__NAME,
+				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Description feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Description feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addDescriptionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_AttributeValue_description_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_AttributeValue_description_feature", "_UI_AttributeValue_type"),
-                 FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE__DESCRIPTION,
-                 false,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_AttributeValue_description_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_AttributeValue_description_feature", "_UI_AttributeValue_type"),
+				 FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE__DESCRIPTION,
+				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Comment feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Comment feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addCommentPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_AttributeValue_comment_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_AttributeValue_comment_feature", "_UI_AttributeValue_type"),
-                 FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE__COMMENT,
-                 false,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_AttributeValue_comment_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_AttributeValue_comment_feature", "_UI_AttributeValue_type"),
+				 FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE__COMMENT,
+				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
      * @generated NOT
@@ -182,48 +182,48 @@ public class AttributeValueItemProvider
     }
     
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(AttributeValue.class)) {
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__NAME:
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__DESCRIPTION:
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__COMMENT:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(AttributeValue.class)) {
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__NAME:
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__DESCRIPTION:
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__COMMENT:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
-    }
+		super.collectNewChildDescriptors(newChildDescriptors, object);
+	}
 
     /**
-     * Return the resource locator for this item provider's resources.
-     * <!-- begin-user-doc -->
+	 * Return the resource locator for this item provider's resources.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public ResourceLocator getResourceLocator() {
-        return FeatureModelEditPlugin.INSTANCE;
-    }
+		return FeatureModelEditPlugin.INSTANCE;
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/BooleanValueItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/BooleanValueItemProvider.java
@@ -28,60 +28,54 @@ import cz.zcu.yafmt.model.fc.FeatureConfigurationPackage;
  * @generated
  */
 public class BooleanValueItemProvider
-    extends AttributeValueItemProvider
-    implements
-        IEditingDomainItemProvider,
-        IStructuredItemContentProvider,
-        ITreeItemContentProvider,
-        IItemLabelProvider,
-        IItemPropertySource {
+    extends AttributeValueItemProvider {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public BooleanValueItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
-     * This returns the property descriptors for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the property descriptors for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
-        if (itemPropertyDescriptors == null) {
-            super.getPropertyDescriptors(object);
+		if (itemPropertyDescriptors == null) {
+			super.getPropertyDescriptors(object);
 
-            addValuePropertyDescriptor(object);
-        }
-        return itemPropertyDescriptors;
-    }
+			addValuePropertyDescriptor(object);
+		}
+		return itemPropertyDescriptors;
+	}
 
     /**
-     * This adds a property descriptor for the Value feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Value feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addValuePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_BooleanValue_value_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_BooleanValue_value_feature", "_UI_BooleanValue_type"),
-                 FeatureConfigurationPackage.Literals.BOOLEAN_VALUE__VALUE,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_BooleanValue_value_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_BooleanValue_value_feature", "_UI_BooleanValue_type"),
+				 FeatureConfigurationPackage.Literals.BOOLEAN_VALUE__VALUE,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
      * This returns BooleanValue.gif.
@@ -106,34 +100,34 @@ public class BooleanValueItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(BooleanValue.class)) {
-            case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(BooleanValue.class)) {
+			case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
-    }
+		super.collectNewChildDescriptors(newChildDescriptors, object);
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/DoubleValueItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/DoubleValueItemProvider.java
@@ -28,60 +28,54 @@ import cz.zcu.yafmt.model.fc.FeatureConfigurationPackage;
  * @generated
  */
 public class DoubleValueItemProvider
-    extends AttributeValueItemProvider
-    implements
-        IEditingDomainItemProvider,
-        IStructuredItemContentProvider,
-        ITreeItemContentProvider,
-        IItemLabelProvider,
-        IItemPropertySource {
+    extends AttributeValueItemProvider {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public DoubleValueItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
-     * This returns the property descriptors for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the property descriptors for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
-        if (itemPropertyDescriptors == null) {
-            super.getPropertyDescriptors(object);
+		if (itemPropertyDescriptors == null) {
+			super.getPropertyDescriptors(object);
 
-            addValuePropertyDescriptor(object);
-        }
-        return itemPropertyDescriptors;
-    }
+			addValuePropertyDescriptor(object);
+		}
+		return itemPropertyDescriptors;
+	}
 
     /**
-     * This adds a property descriptor for the Value feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Value feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addValuePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_DoubleValue_value_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_DoubleValue_value_feature", "_UI_DoubleValue_type"),
-                 FeatureConfigurationPackage.Literals.DOUBLE_VALUE__VALUE,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.REAL_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_DoubleValue_value_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_DoubleValue_value_feature", "_UI_DoubleValue_type"),
+				 FeatureConfigurationPackage.Literals.DOUBLE_VALUE__VALUE,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.REAL_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
 
     /**
@@ -107,34 +101,34 @@ public class DoubleValueItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(DoubleValue.class)) {
-            case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(DoubleValue.class)) {
+			case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
-    }
+		super.collectNewChildDescriptors(newChildDescriptors, object);
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/FeatureConfigurationItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/FeatureConfigurationItemProvider.java
@@ -45,228 +45,228 @@ public class FeatureConfigurationItemProvider
         IItemLabelProvider,
         IItemPropertySource {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureConfigurationItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
-     * This returns the property descriptors for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the property descriptors for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
-        if (itemPropertyDescriptors == null) {
-            super.getPropertyDescriptors(object);
+		if (itemPropertyDescriptors == null) {
+			super.getPropertyDescriptors(object);
 
-            addNamePropertyDescriptor(object);
-            addVersionPropertyDescriptor(object);
-            addDescriptionPropertyDescriptor(object);
-            addCommentPropertyDescriptor(object);
-        }
-        return itemPropertyDescriptors;
-    }
+			addNamePropertyDescriptor(object);
+			addVersionPropertyDescriptor(object);
+			addDescriptionPropertyDescriptor(object);
+			addCommentPropertyDescriptor(object);
+		}
+		return itemPropertyDescriptors;
+	}
 
     /**
-     * This adds a property descriptor for the Name feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Name feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addNamePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_FeatureConfiguration_name_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_FeatureConfiguration_name_feature", "_UI_FeatureConfiguration_type"),
-                 FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__NAME,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_FeatureConfiguration_name_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_FeatureConfiguration_name_feature", "_UI_FeatureConfiguration_type"),
+				 FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__NAME,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Description feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Description feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addDescriptionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_FeatureConfiguration_description_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_FeatureConfiguration_description_feature", "_UI_FeatureConfiguration_type"),
-                 FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__DESCRIPTION,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_FeatureConfiguration_description_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_FeatureConfiguration_description_feature", "_UI_FeatureConfiguration_type"),
+				 FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__DESCRIPTION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Comment feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Comment feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addCommentPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_FeatureConfiguration_comment_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_FeatureConfiguration_comment_feature", "_UI_FeatureConfiguration_type"),
-                 FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__COMMENT,
-                 true,
-                 true,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_FeatureConfiguration_comment_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_FeatureConfiguration_comment_feature", "_UI_FeatureConfiguration_type"),
+				 FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__COMMENT,
+				 true,
+				 true,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Version feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Version feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addVersionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_FeatureConfiguration_version_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_FeatureConfiguration_version_feature", "_UI_FeatureConfiguration_type"),
-                 FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__VERSION,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_FeatureConfiguration_version_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_FeatureConfiguration_version_feature", "_UI_FeatureConfiguration_type"),
+				 FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__VERSION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
-     * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
-     * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
-     * <!-- begin-user-doc -->
+	 * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
+	 * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
+	 * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
-        if (childrenFeatures == null) {
-            super.getChildrenFeatures(object);
-            childrenFeatures.add(FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__ROOT);
-        }
-        return childrenFeatures;
-    }
+		if (childrenFeatures == null) {
+			super.getChildrenFeatures(object);
+			childrenFeatures.add(FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__ROOT);
+		}
+		return childrenFeatures;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EStructuralFeature getChildFeature(Object object, Object child) {
-        // Check the type of the specified child object and return the proper feature to use for
-        // adding (see {@link AddCommand}) it as a child.
+		// Check the type of the specified child object and return the proper feature to use for
+		// adding (see {@link AddCommand}) it as a child.
 
-        return super.getChildFeature(object, child);
-    }
+		return super.getChildFeature(object, child);
+	}
 
     /**
-     * This returns FeatureConfiguration.gif.
-     * <!-- begin-user-doc -->
+	 * This returns FeatureConfiguration.gif.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object getImage(Object object) {
-        return overlayImage(object, getResourceLocator().getImage("full/obj16/FeatureConfiguration"));
-    }
+		return overlayImage(object, getResourceLocator().getImage("full/obj16/FeatureConfiguration"));
+	}
 
     /**
-     * This returns the label text for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the label text for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String getText(Object object) {
-        String label = ((FeatureConfiguration)object).getName();
-        return label == null || label.length() == 0 ?
-            getString("_UI_FeatureConfiguration_type") :
-            getString("_UI_FeatureConfiguration_type") + " " + label;
-    }
+		String label = ((FeatureConfiguration)object).getName();
+		return label == null || label.length() == 0 ?
+			getString("_UI_FeatureConfiguration_type") :
+			getString("_UI_FeatureConfiguration_type") + " " + label;
+	}
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(FeatureConfiguration.class)) {
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(FeatureConfiguration.class)) {
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
+		super.collectNewChildDescriptors(newChildDescriptors, object);
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__ROOT,
-                 FeatureConfigurationFactory.eINSTANCE.createSelection()));
-    }
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION__ROOT,
+				 FeatureConfigurationFactory.eINSTANCE.createSelection()));
+	}
 
     /**
-     * Return the resource locator for this item provider's resources.
-     * <!-- begin-user-doc -->
+	 * Return the resource locator for this item provider's resources.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public ResourceLocator getResourceLocator() {
-        return FeatureModelEditPlugin.INSTANCE;
-    }
+		return FeatureModelEditPlugin.INSTANCE;
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/FeatureConfigurationItemProviderAdapterFactory.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/FeatureConfigurationItemProviderAdapterFactory.java
@@ -34,291 +34,291 @@ import cz.zcu.yafmt.model.fc.util.FeatureConfigurationAdapterFactory;
  */
 public class FeatureConfigurationItemProviderAdapterFactory extends FeatureConfigurationAdapterFactory implements ComposeableAdapterFactory, IChangeNotifier, IDisposable {
     /**
-     * This keeps track of the root adapter factory that delegates to this adapter factory.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the root adapter factory that delegates to this adapter factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ComposedAdapterFactory parentAdapterFactory;
 
     /**
-     * This is used to implement {@link org.eclipse.emf.edit.provider.IChangeNotifier}.
-     * <!-- begin-user-doc -->
+	 * This is used to implement {@link org.eclipse.emf.edit.provider.IChangeNotifier}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected IChangeNotifier changeNotifier = new ChangeNotifier();
 
     /**
-     * This keeps track of all the item providers created, so that they can be {@link #dispose disposed}.
-     * <!-- begin-user-doc -->
+	 * This keeps track of all the item providers created, so that they can be {@link #dispose disposed}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected Disposable disposable = new Disposable();
 
     /**
-     * This keeps track of all the supported types checked by {@link #isFactoryForType isFactoryForType}.
-     * <!-- begin-user-doc -->
+	 * This keeps track of all the supported types checked by {@link #isFactoryForType isFactoryForType}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected Collection<Object> supportedTypes = new ArrayList<Object>();
 
     /**
-     * This constructs an instance.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureConfigurationItemProviderAdapterFactory() {
-        supportedTypes.add(IEditingDomainItemProvider.class);
-        supportedTypes.add(IStructuredItemContentProvider.class);
-        supportedTypes.add(ITreeItemContentProvider.class);
-        supportedTypes.add(IItemLabelProvider.class);
-        supportedTypes.add(IItemPropertySource.class);
-    }
+		supportedTypes.add(IEditingDomainItemProvider.class);
+		supportedTypes.add(IStructuredItemContentProvider.class);
+		supportedTypes.add(ITreeItemContentProvider.class);
+		supportedTypes.add(IItemLabelProvider.class);
+		supportedTypes.add(IItemPropertySource.class);
+	}
 
     /**
-     * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.FeatureConfiguration} instances.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.FeatureConfiguration} instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected FeatureConfigurationItemProvider featureConfigurationItemProvider;
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.FeatureConfiguration}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.FeatureConfiguration}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createFeatureConfigurationAdapter() {
-        if (featureConfigurationItemProvider == null) {
-            featureConfigurationItemProvider = new FeatureConfigurationItemProvider(this);
-        }
+		if (featureConfigurationItemProvider == null) {
+			featureConfigurationItemProvider = new FeatureConfigurationItemProvider(this);
+		}
 
-        return featureConfigurationItemProvider;
-    }
+		return featureConfigurationItemProvider;
+	}
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.Selection}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.Selection}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createSelectionAdapter() {
-        return new SelectionItemProvider(this);
-    }
+		return new SelectionItemProvider(this);
+	}
 
     /**
-     * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.BooleanValue} instances.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.BooleanValue} instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected BooleanValueItemProvider booleanValueItemProvider;
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.BooleanValue}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.BooleanValue}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createBooleanValueAdapter() {
-        if (booleanValueItemProvider == null) {
-            booleanValueItemProvider = new BooleanValueItemProvider(this);
-        }
+		if (booleanValueItemProvider == null) {
+			booleanValueItemProvider = new BooleanValueItemProvider(this);
+		}
 
-        return booleanValueItemProvider;
-    }
+		return booleanValueItemProvider;
+	}
 
     /**
-     * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.IntegerValue} instances.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.IntegerValue} instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected IntegerValueItemProvider integerValueItemProvider;
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.IntegerValue}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.IntegerValue}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createIntegerValueAdapter() {
-        if (integerValueItemProvider == null) {
-            integerValueItemProvider = new IntegerValueItemProvider(this);
-        }
+		if (integerValueItemProvider == null) {
+			integerValueItemProvider = new IntegerValueItemProvider(this);
+		}
 
-        return integerValueItemProvider;
-    }
+		return integerValueItemProvider;
+	}
 
     /**
-     * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.DoubleValue} instances.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.DoubleValue} instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected DoubleValueItemProvider doubleValueItemProvider;
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.DoubleValue}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.DoubleValue}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createDoubleValueAdapter() {
-        if (doubleValueItemProvider == null) {
-            doubleValueItemProvider = new DoubleValueItemProvider(this);
-        }
+		if (doubleValueItemProvider == null) {
+			doubleValueItemProvider = new DoubleValueItemProvider(this);
+		}
 
-        return doubleValueItemProvider;
-    }
+		return doubleValueItemProvider;
+	}
 
     /**
-     * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.StringValue} instances.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fc.StringValue} instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected StringValueItemProvider stringValueItemProvider;
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.StringValue}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fc.StringValue}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createStringValueAdapter() {
-        if (stringValueItemProvider == null) {
-            stringValueItemProvider = new StringValueItemProvider(this);
-        }
+		if (stringValueItemProvider == null) {
+			stringValueItemProvider = new StringValueItemProvider(this);
+		}
 
-        return stringValueItemProvider;
-    }
+		return stringValueItemProvider;
+	}
 
     /**
-     * This returns the root adapter factory that contains this factory.
-     * <!-- begin-user-doc -->
+	 * This returns the root adapter factory that contains this factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ComposeableAdapterFactory getRootAdapterFactory() {
-        return parentAdapterFactory == null ? this : parentAdapterFactory.getRootAdapterFactory();
-    }
+		return parentAdapterFactory == null ? this : parentAdapterFactory.getRootAdapterFactory();
+	}
 
     /**
-     * This sets the composed adapter factory that contains this factory.
-     * <!-- begin-user-doc -->
+	 * This sets the composed adapter factory that contains this factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setParentAdapterFactory(ComposedAdapterFactory parentAdapterFactory) {
-        this.parentAdapterFactory = parentAdapterFactory;
-    }
+		this.parentAdapterFactory = parentAdapterFactory;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean isFactoryForType(Object type) {
-        return supportedTypes.contains(type) || super.isFactoryForType(type);
-    }
+		return supportedTypes.contains(type) || super.isFactoryForType(type);
+	}
 
     /**
-     * This implementation substitutes the factory itself as the key for the adapter.
-     * <!-- begin-user-doc -->
+	 * This implementation substitutes the factory itself as the key for the adapter.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter adapt(Notifier notifier, Object type) {
-        return super.adapt(notifier, this);
-    }
+		return super.adapt(notifier, this);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object adapt(Object object, Object type) {
-        if (isFactoryForType(type)) {
-            Object adapter = super.adapt(object, type);
-            if (!(type instanceof Class<?>) || (((Class<?>)type).isInstance(adapter))) {
-                return adapter;
-            }
-        }
+		if (isFactoryForType(type)) {
+			Object adapter = super.adapt(object, type);
+			if (!(type instanceof Class<?>) || (((Class<?>)type).isInstance(adapter))) {
+				return adapter;
+			}
+		}
 
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Associates an adapter with a notifier via the base implementation, then records it to ensure it will be disposed.
-     * <!-- begin-user-doc -->
+	 * Associates an adapter with a notifier via the base implementation, then records it to ensure it will be disposed.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void associate(Adapter adapter, Notifier target) {
-        super.associate(adapter, target);
-        if (adapter != null) {
-            disposable.add(adapter);
-        }
-    }
+		super.associate(adapter, target);
+		if (adapter != null) {
+			disposable.add(adapter);
+		}
+	}
 
     /**
-     * This adds a listener.
-     * <!-- begin-user-doc -->
+	 * This adds a listener.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void addListener(INotifyChangedListener notifyChangedListener) {
-        changeNotifier.addListener(notifyChangedListener);
-    }
+		changeNotifier.addListener(notifyChangedListener);
+	}
 
     /**
-     * This removes a listener.
-     * <!-- begin-user-doc -->
+	 * This removes a listener.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void removeListener(INotifyChangedListener notifyChangedListener) {
-        changeNotifier.removeListener(notifyChangedListener);
-    }
+		changeNotifier.removeListener(notifyChangedListener);
+	}
 
     /**
-     * This delegates to {@link #changeNotifier} and to {@link #parentAdapterFactory}.
-     * <!-- begin-user-doc -->
+	 * This delegates to {@link #changeNotifier} and to {@link #parentAdapterFactory}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void fireNotifyChanged(Notification notification) {
-        changeNotifier.fireNotifyChanged(notification);
+		changeNotifier.fireNotifyChanged(notification);
 
-        if (parentAdapterFactory != null) {
-            parentAdapterFactory.fireNotifyChanged(notification);
-        }
-    }
+		if (parentAdapterFactory != null) {
+			parentAdapterFactory.fireNotifyChanged(notification);
+		}
+	}
 
     /**
-     * This disposes all of the item providers created by this factory. 
-     * <!-- begin-user-doc -->
+	 * This disposes all of the item providers created by this factory. 
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void dispose() {
-        disposable.dispose();
-    }
+		disposable.dispose();
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/IntegerValueItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/IntegerValueItemProvider.java
@@ -28,60 +28,54 @@ import cz.zcu.yafmt.model.fc.IntegerValue;
  * @generated
  */
 public class IntegerValueItemProvider
-    extends AttributeValueItemProvider
-    implements
-        IEditingDomainItemProvider,
-        IStructuredItemContentProvider,
-        ITreeItemContentProvider,
-        IItemLabelProvider,
-        IItemPropertySource {
+    extends AttributeValueItemProvider {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public IntegerValueItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
-     * This returns the property descriptors for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the property descriptors for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
-        if (itemPropertyDescriptors == null) {
-            super.getPropertyDescriptors(object);
+		if (itemPropertyDescriptors == null) {
+			super.getPropertyDescriptors(object);
 
-            addValuePropertyDescriptor(object);
-        }
-        return itemPropertyDescriptors;
-    }
+			addValuePropertyDescriptor(object);
+		}
+		return itemPropertyDescriptors;
+	}
 
     /**
-     * This adds a property descriptor for the Value feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Value feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addValuePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_IntegerValue_value_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_IntegerValue_value_feature", "_UI_IntegerValue_type"),
-                 FeatureConfigurationPackage.Literals.INTEGER_VALUE__VALUE,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_IntegerValue_value_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_IntegerValue_value_feature", "_UI_IntegerValue_type"),
+				 FeatureConfigurationPackage.Literals.INTEGER_VALUE__VALUE,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
      * This returns IntegerValue.gif.
@@ -106,34 +100,34 @@ public class IntegerValueItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(IntegerValue.class)) {
-            case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(IntegerValue.class)) {
+			case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
-    }
+		super.collectNewChildDescriptors(newChildDescriptors, object);
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/SelectionItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/SelectionItemProvider.java
@@ -42,14 +42,14 @@ public class SelectionItemProvider
         IItemLabelProvider,
         IItemPropertySource {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public SelectionItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
      * This returns the property descriptors for the adapted class.
@@ -77,123 +77,123 @@ public class SelectionItemProvider
     }
 
     /**
-     * This adds a property descriptor for the Id feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Id feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addIdPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Selection_id_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Selection_id_feature", "_UI_Selection_type"),
-                 FeatureConfigurationPackage.Literals.SELECTION__ID,
-                 false,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Selection_id_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Selection_id_feature", "_UI_Selection_type"),
+				 FeatureConfigurationPackage.Literals.SELECTION__ID,
+				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Name feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Name feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addNamePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Selection_name_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Selection_name_feature", "_UI_Selection_type"),
-                 FeatureConfigurationPackage.Literals.SELECTION__NAME,
-                 false,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Selection_name_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Selection_name_feature", "_UI_Selection_type"),
+				 FeatureConfigurationPackage.Literals.SELECTION__NAME,
+				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Description feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Description feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addDescriptionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Selection_description_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Selection_description_feature", "_UI_Selection_type"),
-                 FeatureConfigurationPackage.Literals.SELECTION__DESCRIPTION,
-                 false,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Selection_description_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Selection_description_feature", "_UI_Selection_type"),
+				 FeatureConfigurationPackage.Literals.SELECTION__DESCRIPTION,
+				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Comment feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Comment feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addCommentPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Selection_comment_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Selection_comment_feature", "_UI_Selection_type"),
-                 FeatureConfigurationPackage.Literals.SELECTION__COMMENT,
-                 false,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Selection_comment_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Selection_comment_feature", "_UI_Selection_type"),
+				 FeatureConfigurationPackage.Literals.SELECTION__COMMENT,
+				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
-     * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
-     * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
-     * <!-- begin-user-doc -->
+	 * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
+	 * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
+	 * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
-        if (childrenFeatures == null) {
-            super.getChildrenFeatures(object);
-            childrenFeatures.add(FeatureConfigurationPackage.Literals.SELECTION__VALUES);
-            childrenFeatures.add(FeatureConfigurationPackage.Literals.SELECTION__SELECTIONS);
-        }
-        return childrenFeatures;
-    }
+		if (childrenFeatures == null) {
+			super.getChildrenFeatures(object);
+			childrenFeatures.add(FeatureConfigurationPackage.Literals.SELECTION__VALUES);
+			childrenFeatures.add(FeatureConfigurationPackage.Literals.SELECTION__SELECTIONS);
+		}
+		return childrenFeatures;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EStructuralFeature getChildFeature(Object object, Object child) {
-        // Check the type of the specified child object and return the proper feature to use for
-        // adding (see {@link AddCommand}) it as a child.
+		// Check the type of the specified child object and return the proper feature to use for
+		// adding (see {@link AddCommand}) it as a child.
 
-        return super.getChildFeature(object, child);
-    }
+		return super.getChildFeature(object, child);
+	}
 
     /**
      * This returns Selection.gif.
@@ -230,78 +230,78 @@ public class SelectionItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(Selection.class)) {
-            case FeatureConfigurationPackage.SELECTION__ID:
-            case FeatureConfigurationPackage.SELECTION__NAME:
-            case FeatureConfigurationPackage.SELECTION__DESCRIPTION:
-            case FeatureConfigurationPackage.SELECTION__COMMENT:
-            case FeatureConfigurationPackage.SELECTION__ROOT:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-            case FeatureConfigurationPackage.SELECTION__VALUES:
-            case FeatureConfigurationPackage.SELECTION__SELECTIONS:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(Selection.class)) {
+			case FeatureConfigurationPackage.SELECTION__ID:
+			case FeatureConfigurationPackage.SELECTION__NAME:
+			case FeatureConfigurationPackage.SELECTION__DESCRIPTION:
+			case FeatureConfigurationPackage.SELECTION__COMMENT:
+			case FeatureConfigurationPackage.SELECTION__ROOT:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+			case FeatureConfigurationPackage.SELECTION__VALUES:
+			case FeatureConfigurationPackage.SELECTION__SELECTIONS:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
+		super.collectNewChildDescriptors(newChildDescriptors, object);
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureConfigurationPackage.Literals.SELECTION__VALUES,
-                 FeatureConfigurationFactory.eINSTANCE.createBooleanValue()));
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureConfigurationPackage.Literals.SELECTION__VALUES,
+				 FeatureConfigurationFactory.eINSTANCE.createBooleanValue()));
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureConfigurationPackage.Literals.SELECTION__VALUES,
-                 FeatureConfigurationFactory.eINSTANCE.createIntegerValue()));
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureConfigurationPackage.Literals.SELECTION__VALUES,
+				 FeatureConfigurationFactory.eINSTANCE.createIntegerValue()));
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureConfigurationPackage.Literals.SELECTION__VALUES,
-                 FeatureConfigurationFactory.eINSTANCE.createDoubleValue()));
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureConfigurationPackage.Literals.SELECTION__VALUES,
+				 FeatureConfigurationFactory.eINSTANCE.createDoubleValue()));
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureConfigurationPackage.Literals.SELECTION__VALUES,
-                 FeatureConfigurationFactory.eINSTANCE.createStringValue()));
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureConfigurationPackage.Literals.SELECTION__VALUES,
+				 FeatureConfigurationFactory.eINSTANCE.createStringValue()));
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureConfigurationPackage.Literals.SELECTION__SELECTIONS,
-                 FeatureConfigurationFactory.eINSTANCE.createSelection()));
-    }
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureConfigurationPackage.Literals.SELECTION__SELECTIONS,
+				 FeatureConfigurationFactory.eINSTANCE.createSelection()));
+	}
 
     /**
-     * Return the resource locator for this item provider's resources.
-     * <!-- begin-user-doc -->
+	 * Return the resource locator for this item provider's resources.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public ResourceLocator getResourceLocator() {
-        return FeatureModelEditPlugin.INSTANCE;
-    }
+		return FeatureModelEditPlugin.INSTANCE;
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/StringValueItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fc/provider/StringValueItemProvider.java
@@ -28,60 +28,54 @@ import cz.zcu.yafmt.model.fc.StringValue;
  * @generated
  */
 public class StringValueItemProvider
-    extends AttributeValueItemProvider
-    implements
-        IEditingDomainItemProvider,
-        IStructuredItemContentProvider,
-        ITreeItemContentProvider,
-        IItemLabelProvider,
-        IItemPropertySource {
+    extends AttributeValueItemProvider {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public StringValueItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
-     * This returns the property descriptors for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the property descriptors for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
-        if (itemPropertyDescriptors == null) {
-            super.getPropertyDescriptors(object);
+		if (itemPropertyDescriptors == null) {
+			super.getPropertyDescriptors(object);
 
-            addValuePropertyDescriptor(object);
-        }
-        return itemPropertyDescriptors;
-    }
+			addValuePropertyDescriptor(object);
+		}
+		return itemPropertyDescriptors;
+	}
 
     /**
-     * This adds a property descriptor for the Value feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Value feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addValuePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_StringValue_value_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_StringValue_value_feature", "_UI_StringValue_type"),
-                 FeatureConfigurationPackage.Literals.STRING_VALUE__VALUE,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_StringValue_value_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_StringValue_value_feature", "_UI_StringValue_type"),
+				 FeatureConfigurationPackage.Literals.STRING_VALUE__VALUE,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
      * This returns StringValue.gif.
@@ -106,34 +100,34 @@ public class StringValueItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(StringValue.class)) {
-            case FeatureConfigurationPackage.STRING_VALUE__VALUE:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(StringValue.class)) {
+			case FeatureConfigurationPackage.STRING_VALUE__VALUE:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
-    }
+		super.collectNewChildDescriptors(newChildDescriptors, object);
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/AttributeItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/AttributeItemProvider.java
@@ -40,146 +40,169 @@ public class AttributeItemProvider
         IItemLabelProvider,
         IItemPropertySource {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public AttributeItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
-     * This returns the property descriptors for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the property descriptors for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
-        if (itemPropertyDescriptors == null) {
-            super.getPropertyDescriptors(object);
+		if (itemPropertyDescriptors == null) {
+			super.getPropertyDescriptors(object);
 
-            addIdPropertyDescriptor(object);
-            addNamePropertyDescriptor(object);
-            addTypePropertyDescriptor(object);
-            addDescriptionPropertyDescriptor(object);
-            addCommentPropertyDescriptor(object);
-        }
-        return itemPropertyDescriptors;
-    }
+			addIdPropertyDescriptor(object);
+			addNamePropertyDescriptor(object);
+			addTypePropertyDescriptor(object);
+			addValuePropertyDescriptor(object);
+			addDescriptionPropertyDescriptor(object);
+			addCommentPropertyDescriptor(object);
+		}
+		return itemPropertyDescriptors;
+	}
 
     /**
-     * This adds a property descriptor for the Id feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Id feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addIdPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Attribute_id_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_id_feature", "_UI_Attribute_type"),
-                 FeatureModelPackage.Literals.ATTRIBUTE__ID,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Attribute_id_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_id_feature", "_UI_Attribute_type"),
+				 FeatureModelPackage.Literals.ATTRIBUTE__ID,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Name feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Name feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addNamePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Attribute_name_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_name_feature", "_UI_Attribute_type"),
-                 FeatureModelPackage.Literals.ATTRIBUTE__NAME,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Attribute_name_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_name_feature", "_UI_Attribute_type"),
+				 FeatureModelPackage.Literals.ATTRIBUTE__NAME,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Description feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Description feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addDescriptionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Attribute_description_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_description_feature", "_UI_Attribute_type"),
-                 FeatureModelPackage.Literals.ATTRIBUTE__DESCRIPTION,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Attribute_description_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_description_feature", "_UI_Attribute_type"),
+				 FeatureModelPackage.Literals.ATTRIBUTE__DESCRIPTION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Comment feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Comment feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addCommentPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Attribute_comment_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_comment_feature", "_UI_Attribute_type"),
-                 FeatureModelPackage.Literals.ATTRIBUTE__COMMENT,
-                 true,
-                 true,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Attribute_comment_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_comment_feature", "_UI_Attribute_type"),
+				 FeatureModelPackage.Literals.ATTRIBUTE__COMMENT,
+				 true,
+				 true,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Type feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Type feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addTypePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Attribute_type_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_type_feature", "_UI_Attribute_type"),
-                 FeatureModelPackage.Literals.ATTRIBUTE__TYPE,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Attribute_type_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_type_feature", "_UI_Attribute_type"),
+				 FeatureModelPackage.Literals.ATTRIBUTE__TYPE,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
+	 * This adds a property descriptor for the Value feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addValuePropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Attribute_value_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Attribute_value_feature", "_UI_Attribute_type"),
+				 FeatureModelPackage.Literals.ATTRIBUTE__VALUE,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
+
+				/**
      * This returns Attribute.gif.
      * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
@@ -202,49 +225,50 @@ public class AttributeItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(Attribute.class)) {
-            case FeatureModelPackage.ATTRIBUTE__ID:
-            case FeatureModelPackage.ATTRIBUTE__NAME:
-            case FeatureModelPackage.ATTRIBUTE__TYPE:
-            case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
-            case FeatureModelPackage.ATTRIBUTE__COMMENT:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(Attribute.class)) {
+			case FeatureModelPackage.ATTRIBUTE__ID:
+			case FeatureModelPackage.ATTRIBUTE__NAME:
+			case FeatureModelPackage.ATTRIBUTE__TYPE:
+			case FeatureModelPackage.ATTRIBUTE__VALUE:
+			case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
+			case FeatureModelPackage.ATTRIBUTE__COMMENT:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
-    }
+		super.collectNewChildDescriptors(newChildDescriptors, object);
+	}
 
     /**
-     * Return the resource locator for this item provider's resources.
-     * <!-- begin-user-doc -->
+	 * Return the resource locator for this item provider's resources.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public ResourceLocator getResourceLocator() {
-        return FeatureModelEditPlugin.INSTANCE;
-    }
+		return FeatureModelEditPlugin.INSTANCE;
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/ConstraintItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/ConstraintItemProvider.java
@@ -42,55 +42,55 @@ public class ConstraintItemProvider
         IItemLabelProvider,
         IItemPropertySource {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ConstraintItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
-     * This returns the property descriptors for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the property descriptors for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
-        if (itemPropertyDescriptors == null) {
-            super.getPropertyDescriptors(object);
+		if (itemPropertyDescriptors == null) {
+			super.getPropertyDescriptors(object);
 
-            addValuePropertyDescriptor(object);
-            addLanguagePropertyDescriptor(object);
-            addDescriptionPropertyDescriptor(object);
-            addCommentPropertyDescriptor(object);
-        }
-        return itemPropertyDescriptors;
-    }
+			addValuePropertyDescriptor(object);
+			addLanguagePropertyDescriptor(object);
+			addDescriptionPropertyDescriptor(object);
+			addCommentPropertyDescriptor(object);
+		}
+		return itemPropertyDescriptors;
+	}
 
     /**
-     * This adds a property descriptor for the Value feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Value feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addValuePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Constraint_value_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Constraint_value_feature", "_UI_Constraint_type"),
-                 FeatureModelPackage.Literals.CONSTRAINT__VALUE,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Constraint_value_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Constraint_value_feature", "_UI_Constraint_type"),
+				 FeatureModelPackage.Literals.CONSTRAINT__VALUE,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
      * This adds a property descriptor for the Language feature.
@@ -154,48 +154,48 @@ public class ConstraintItemProvider
     }
 
     /**
-     * This adds a property descriptor for the Description feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Description feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addDescriptionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Constraint_description_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Constraint_description_feature", "_UI_Constraint_type"),
-                 FeatureModelPackage.Literals.CONSTRAINT__DESCRIPTION,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Constraint_description_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Constraint_description_feature", "_UI_Constraint_type"),
+				 FeatureModelPackage.Literals.CONSTRAINT__DESCRIPTION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Comment feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Comment feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addCommentPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Constraint_comment_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Constraint_comment_feature", "_UI_Constraint_type"),
-                 FeatureModelPackage.Literals.CONSTRAINT__COMMENT,
-                 true,
-                 true,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Constraint_comment_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Constraint_comment_feature", "_UI_Constraint_type"),
+				 FeatureModelPackage.Literals.CONSTRAINT__COMMENT,
+				 true,
+				 true,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
      * This returns Constraint.gif.
@@ -220,48 +220,48 @@ public class ConstraintItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(Constraint.class)) {
-            case FeatureModelPackage.CONSTRAINT__VALUE:
-            case FeatureModelPackage.CONSTRAINT__LANGUAGE:
-            case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
-            case FeatureModelPackage.CONSTRAINT__COMMENT:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(Constraint.class)) {
+			case FeatureModelPackage.CONSTRAINT__VALUE:
+			case FeatureModelPackage.CONSTRAINT__LANGUAGE:
+			case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
+			case FeatureModelPackage.CONSTRAINT__COMMENT:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
-    }
+		super.collectNewChildDescriptors(newChildDescriptors, object);
+	}
 
     /**
-     * Return the resource locator for this item provider's resources.
-     * <!-- begin-user-doc -->
+	 * Return the resource locator for this item provider's resources.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public ResourceLocator getResourceLocator() {
-        return FeatureModelEditPlugin.INSTANCE;
-    }
+		return FeatureModelEditPlugin.INSTANCE;
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/FeatureItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/FeatureItemProvider.java
@@ -38,14 +38,14 @@ public class FeatureItemProvider
         IItemLabelProvider,
         IItemPropertySource {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
      * This returns the property descriptors for the adapted class.
@@ -72,190 +72,190 @@ public class FeatureItemProvider
     }
 
     /**
-     * This adds a property descriptor for the Id feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Id feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addIdPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Feature_id_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Feature_id_feature", "_UI_Feature_type"),
-                 FeatureModelPackage.Literals.FEATURE__ID,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Feature_id_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Feature_id_feature", "_UI_Feature_type"),
+				 FeatureModelPackage.Literals.FEATURE__ID,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Name feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Name feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addNamePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Feature_name_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Feature_name_feature", "_UI_Feature_type"),
-                 FeatureModelPackage.Literals.FEATURE__NAME,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Feature_name_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Feature_name_feature", "_UI_Feature_type"),
+				 FeatureModelPackage.Literals.FEATURE__NAME,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Description feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Description feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addDescriptionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Feature_description_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Feature_description_feature", "_UI_Feature_type"),
-                 FeatureModelPackage.Literals.FEATURE__DESCRIPTION,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Feature_description_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Feature_description_feature", "_UI_Feature_type"),
+				 FeatureModelPackage.Literals.FEATURE__DESCRIPTION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Comment feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Comment feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addCommentPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Feature_comment_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Feature_comment_feature", "_UI_Feature_type"),
-                 FeatureModelPackage.Literals.FEATURE__COMMENT,
-                 true,
-                 true,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Feature_comment_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Feature_comment_feature", "_UI_Feature_type"),
+				 FeatureModelPackage.Literals.FEATURE__COMMENT,
+				 true,
+				 true,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Lower feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Lower feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addLowerPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Feature_lower_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Feature_lower_feature", "_UI_Feature_type"),
-                 FeatureModelPackage.Literals.FEATURE__LOWER,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Feature_lower_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Feature_lower_feature", "_UI_Feature_type"),
+				 FeatureModelPackage.Literals.FEATURE__LOWER,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Upper feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Upper feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addUpperPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Feature_upper_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Feature_upper_feature", "_UI_Feature_type"),
-                 FeatureModelPackage.Literals.FEATURE__UPPER,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Feature_upper_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Feature_upper_feature", "_UI_Feature_type"),
+				 FeatureModelPackage.Literals.FEATURE__UPPER,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Cloneable feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Cloneable feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addCloneablePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Feature_cloneable_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Feature_cloneable_feature", "_UI_Feature_type"),
-                 FeatureModelPackage.Literals.FEATURE__CLONEABLE,
-                 false,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Feature_cloneable_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Feature_cloneable_feature", "_UI_Feature_type"),
+				 FeatureModelPackage.Literals.FEATURE__CLONEABLE,
+				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
-     * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
-     * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
-     * <!-- begin-user-doc -->
+	 * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
+	 * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
+	 * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
-        if (childrenFeatures == null) {
-            super.getChildrenFeatures(object);
-            childrenFeatures.add(FeatureModelPackage.Literals.FEATURE__ATTRIBUTES);
-            childrenFeatures.add(FeatureModelPackage.Literals.FEATURE__FEATURES);
-            childrenFeatures.add(FeatureModelPackage.Literals.FEATURE__GROUPS);
-        }
-        return childrenFeatures;
-    }
+		if (childrenFeatures == null) {
+			super.getChildrenFeatures(object);
+			childrenFeatures.add(FeatureModelPackage.Literals.FEATURE__ATTRIBUTES);
+			childrenFeatures.add(FeatureModelPackage.Literals.FEATURE__FEATURES);
+			childrenFeatures.add(FeatureModelPackage.Literals.FEATURE__GROUPS);
+		}
+		return childrenFeatures;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EStructuralFeature getChildFeature(Object object, Object child) {
-        // Check the type of the specified child object and return the proper feature to use for
-        // adding (see {@link AddCommand}) it as a child.
+		// Check the type of the specified child object and return the proper feature to use for
+		// adding (see {@link AddCommand}) it as a child.
 
-        return super.getChildFeature(object, child);
-    }
+		return super.getChildFeature(object, child);
+	}
 
     /**
      * This returns Feature.gif.
@@ -292,75 +292,75 @@ public class FeatureItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(Feature.class)) {
-            case FeatureModelPackage.FEATURE__ID:
-            case FeatureModelPackage.FEATURE__NAME:
-            case FeatureModelPackage.FEATURE__DESCRIPTION:
-            case FeatureModelPackage.FEATURE__COMMENT:
-            case FeatureModelPackage.FEATURE__LOWER:
-            case FeatureModelPackage.FEATURE__UPPER:
-            case FeatureModelPackage.FEATURE__ROOT:
-            case FeatureModelPackage.FEATURE__ORPHAN:
-            case FeatureModelPackage.FEATURE__OPTIONAL:
-            case FeatureModelPackage.FEATURE__MANDATORY:
-            case FeatureModelPackage.FEATURE__CLONEABLE:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-            case FeatureModelPackage.FEATURE__ATTRIBUTES:
-            case FeatureModelPackage.FEATURE__FEATURES:
-            case FeatureModelPackage.FEATURE__GROUPS:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(Feature.class)) {
+			case FeatureModelPackage.FEATURE__ID:
+			case FeatureModelPackage.FEATURE__NAME:
+			case FeatureModelPackage.FEATURE__DESCRIPTION:
+			case FeatureModelPackage.FEATURE__COMMENT:
+			case FeatureModelPackage.FEATURE__LOWER:
+			case FeatureModelPackage.FEATURE__UPPER:
+			case FeatureModelPackage.FEATURE__ROOT:
+			case FeatureModelPackage.FEATURE__ORPHAN:
+			case FeatureModelPackage.FEATURE__OPTIONAL:
+			case FeatureModelPackage.FEATURE__MANDATORY:
+			case FeatureModelPackage.FEATURE__CLONEABLE:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+			case FeatureModelPackage.FEATURE__ATTRIBUTES:
+			case FeatureModelPackage.FEATURE__FEATURES:
+			case FeatureModelPackage.FEATURE__GROUPS:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
+		super.collectNewChildDescriptors(newChildDescriptors, object);
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureModelPackage.Literals.FEATURE__ATTRIBUTES,
-                 FeatureModelFactory.eINSTANCE.createAttribute()));
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureModelPackage.Literals.FEATURE__ATTRIBUTES,
+				 FeatureModelFactory.eINSTANCE.createAttribute()));
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureModelPackage.Literals.FEATURE__FEATURES,
-                 FeatureModelFactory.eINSTANCE.createFeature()));
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureModelPackage.Literals.FEATURE__FEATURES,
+				 FeatureModelFactory.eINSTANCE.createFeature()));
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureModelPackage.Literals.FEATURE__GROUPS,
-                 FeatureModelFactory.eINSTANCE.createGroup()));
-    }
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureModelPackage.Literals.FEATURE__GROUPS,
+				 FeatureModelFactory.eINSTANCE.createGroup()));
+	}
 
     /**
-     * Return the resource locator for this item provider's resources.
-     * <!-- begin-user-doc -->
+	 * Return the resource locator for this item provider's resources.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public ResourceLocator getResourceLocator() {
-        return FeatureModelEditPlugin.INSTANCE;
-    }
+		return FeatureModelEditPlugin.INSTANCE;
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/FeatureModelEditPlugin.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/FeatureModelEditPlugin.java
@@ -14,76 +14,76 @@ import org.eclipse.emf.common.util.ResourceLocator;
  */
 public final class FeatureModelEditPlugin extends EMFPlugin {
     /**
-     * Keep track of the singleton.
-     * <!-- begin-user-doc -->
+	 * Keep track of the singleton.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public static final FeatureModelEditPlugin INSTANCE = new FeatureModelEditPlugin();
 
     /**
-     * Keep track of the singleton.
-     * <!-- begin-user-doc -->
+	 * Keep track of the singleton.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private static Implementation plugin;
 
     /**
-     * Create the instance.
-     * <!-- begin-user-doc -->
+	 * Create the instance.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModelEditPlugin() {
-        super
-          (new ResourceLocator [] {
-           });
-    }
+		super
+		  (new ResourceLocator [] {
+		   });
+	}
 
     /**
-     * Returns the singleton instance of the Eclipse plugin.
-     * <!-- begin-user-doc -->
+	 * Returns the singleton instance of the Eclipse plugin.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the singleton instance.
-     * @generated
-     */
+	 * @return the singleton instance.
+	 * @generated
+	 */
     @Override
     public ResourceLocator getPluginResourceLocator() {
-        return plugin;
-    }
+		return plugin;
+	}
 
     /**
-     * Returns the singleton instance of the Eclipse plugin.
-     * <!-- begin-user-doc -->
+	 * Returns the singleton instance of the Eclipse plugin.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the singleton instance.
-     * @generated
-     */
+	 * @return the singleton instance.
+	 * @generated
+	 */
     public static Implementation getPlugin() {
-        return plugin;
-    }
+		return plugin;
+	}
 
     /**
-     * The actual implementation of the Eclipse <b>Plugin</b>.
-     * <!-- begin-user-doc -->
+	 * The actual implementation of the Eclipse <b>Plugin</b>.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public static class Implementation extends EclipsePlugin {
         /**
-         * Creates an instance.
-         * <!-- begin-user-doc -->
+		 * Creates an instance.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         public Implementation() {
-            super();
+			super();
 
-            // Remember the static instance.
-            //
-            plugin = this;
-        }
+			// Remember the static instance.
+			//
+			plugin = this;
+		}
     }
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/FeatureModelItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/FeatureModelItemProvider.java
@@ -43,164 +43,164 @@ public class FeatureModelItemProvider
         IItemLabelProvider,
         IItemPropertySource {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModelItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
-     * This returns the property descriptors for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the property descriptors for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
-        if (itemPropertyDescriptors == null) {
-            super.getPropertyDescriptors(object);
+		if (itemPropertyDescriptors == null) {
+			super.getPropertyDescriptors(object);
 
-            addNamePropertyDescriptor(object);
-            addVersionPropertyDescriptor(object);
-            addDescriptionPropertyDescriptor(object);
-            addCommentPropertyDescriptor(object);
-        }
-        return itemPropertyDescriptors;
-    }
+			addNamePropertyDescriptor(object);
+			addVersionPropertyDescriptor(object);
+			addDescriptionPropertyDescriptor(object);
+			addCommentPropertyDescriptor(object);
+		}
+		return itemPropertyDescriptors;
+	}
 
     /**
-     * This adds a property descriptor for the Name feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Name feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addNamePropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_FeatureModel_name_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_FeatureModel_name_feature", "_UI_FeatureModel_type"),
-                 FeatureModelPackage.Literals.FEATURE_MODEL__NAME,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_FeatureModel_name_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_FeatureModel_name_feature", "_UI_FeatureModel_type"),
+				 FeatureModelPackage.Literals.FEATURE_MODEL__NAME,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Description feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Description feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addDescriptionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_FeatureModel_description_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_FeatureModel_description_feature", "_UI_FeatureModel_type"),
-                 FeatureModelPackage.Literals.FEATURE_MODEL__DESCRIPTION,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_FeatureModel_description_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_FeatureModel_description_feature", "_UI_FeatureModel_type"),
+				 FeatureModelPackage.Literals.FEATURE_MODEL__DESCRIPTION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Comment feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Comment feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addCommentPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_FeatureModel_comment_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_FeatureModel_comment_feature", "_UI_FeatureModel_type"),
-                 FeatureModelPackage.Literals.FEATURE_MODEL__COMMENT,
-                 true,
-                 true,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_FeatureModel_comment_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_FeatureModel_comment_feature", "_UI_FeatureModel_type"),
+				 FeatureModelPackage.Literals.FEATURE_MODEL__COMMENT,
+				 true,
+				 true,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Version feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Version feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addVersionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_FeatureModel_version_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_FeatureModel_version_feature", "_UI_FeatureModel_type"),
-                 FeatureModelPackage.Literals.FEATURE_MODEL__VERSION,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_FeatureModel_version_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_FeatureModel_version_feature", "_UI_FeatureModel_type"),
+				 FeatureModelPackage.Literals.FEATURE_MODEL__VERSION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
-     * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
-     * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
-     * <!-- begin-user-doc -->
+	 * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
+	 * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
+	 * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
-        if (childrenFeatures == null) {
-            super.getChildrenFeatures(object);
-            childrenFeatures.add(FeatureModelPackage.Literals.FEATURE_MODEL__ROOT);
-            childrenFeatures.add(FeatureModelPackage.Literals.FEATURE_MODEL__ORPHANS);
-            childrenFeatures.add(FeatureModelPackage.Literals.FEATURE_MODEL__CONSTRAINTS);
-        }
-        return childrenFeatures;
-    }
+		if (childrenFeatures == null) {
+			super.getChildrenFeatures(object);
+			childrenFeatures.add(FeatureModelPackage.Literals.FEATURE_MODEL__ROOT);
+			childrenFeatures.add(FeatureModelPackage.Literals.FEATURE_MODEL__ORPHANS);
+			childrenFeatures.add(FeatureModelPackage.Literals.FEATURE_MODEL__CONSTRAINTS);
+		}
+		return childrenFeatures;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EStructuralFeature getChildFeature(Object object, Object child) {
-        // Check the type of the specified child object and return the proper feature to use for
-        // adding (see {@link AddCommand}) it as a child.
+		// Check the type of the specified child object and return the proper feature to use for
+		// adding (see {@link AddCommand}) it as a child.
 
-        return super.getChildFeature(object, child);
-    }
+		return super.getChildFeature(object, child);
+	}
 
     /**
-     * This returns FeatureModel.gif.
-     * <!-- begin-user-doc -->
+	 * This returns FeatureModel.gif.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object getImage(Object object) {
-        return overlayImage(object, getResourceLocator().getImage("full/obj16/FeatureModel"));
-    }
+		return overlayImage(object, getResourceLocator().getImage("full/obj16/FeatureModel"));
+	}
 
     /**
      * This returns the label text for the adapted class.
@@ -214,91 +214,91 @@ public class FeatureModelItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(FeatureModel.class)) {
-            case FeatureModelPackage.FEATURE_MODEL__NAME:
-            case FeatureModelPackage.FEATURE_MODEL__VERSION:
-            case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
-            case FeatureModelPackage.FEATURE_MODEL__COMMENT:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__ROOT:
-            case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
-            case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(FeatureModel.class)) {
+			case FeatureModelPackage.FEATURE_MODEL__NAME:
+			case FeatureModelPackage.FEATURE_MODEL__VERSION:
+			case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
+			case FeatureModelPackage.FEATURE_MODEL__COMMENT:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__ROOT:
+			case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
+			case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
+		super.collectNewChildDescriptors(newChildDescriptors, object);
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureModelPackage.Literals.FEATURE_MODEL__ROOT,
-                 FeatureModelFactory.eINSTANCE.createFeature()));
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureModelPackage.Literals.FEATURE_MODEL__ROOT,
+				 FeatureModelFactory.eINSTANCE.createFeature()));
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureModelPackage.Literals.FEATURE_MODEL__ORPHANS,
-                 FeatureModelFactory.eINSTANCE.createFeature()));
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureModelPackage.Literals.FEATURE_MODEL__ORPHANS,
+				 FeatureModelFactory.eINSTANCE.createFeature()));
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureModelPackage.Literals.FEATURE_MODEL__CONSTRAINTS,
-                 FeatureModelFactory.eINSTANCE.createConstraint()));
-    }
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureModelPackage.Literals.FEATURE_MODEL__CONSTRAINTS,
+				 FeatureModelFactory.eINSTANCE.createConstraint()));
+	}
 
     /**
-     * This returns the label text for {@link org.eclipse.emf.edit.command.CreateChildCommand}.
-     * <!-- begin-user-doc -->
+	 * This returns the label text for {@link org.eclipse.emf.edit.command.CreateChildCommand}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String getCreateChildText(Object owner, Object feature, Object child, Collection<?> selection) {
-        Object childFeature = feature;
-        Object childObject = child;
+		Object childFeature = feature;
+		Object childObject = child;
 
-        boolean qualify =
-            childFeature == FeatureModelPackage.Literals.FEATURE_MODEL__ROOT ||
-            childFeature == FeatureModelPackage.Literals.FEATURE_MODEL__ORPHANS;
+		boolean qualify =
+			childFeature == FeatureModelPackage.Literals.FEATURE_MODEL__ROOT ||
+			childFeature == FeatureModelPackage.Literals.FEATURE_MODEL__ORPHANS;
 
-        if (qualify) {
-            return getString
-                ("_UI_CreateChild_text2",
-                 new Object[] { getTypeText(childObject), getFeatureText(childFeature), getTypeText(owner) });
-        }
-        return super.getCreateChildText(owner, feature, child, selection);
-    }
+		if (qualify) {
+			return getString
+				("_UI_CreateChild_text2",
+				 new Object[] { getTypeText(childObject), getFeatureText(childFeature), getTypeText(owner) });
+		}
+		return super.getCreateChildText(owner, feature, child, selection);
+	}
 
     /**
-     * Return the resource locator for this item provider's resources.
-     * <!-- begin-user-doc -->
+	 * Return the resource locator for this item provider's resources.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public ResourceLocator getResourceLocator() {
-        return FeatureModelEditPlugin.INSTANCE;
-    }
+		return FeatureModelEditPlugin.INSTANCE;
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/FeatureModelItemProviderAdapterFactory.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/FeatureModelItemProviderAdapterFactory.java
@@ -35,268 +35,268 @@ import org.eclipse.emf.edit.provider.ITreeItemContentProvider;
  */
 public class FeatureModelItemProviderAdapterFactory extends FeatureModelAdapterFactory implements ComposeableAdapterFactory, IChangeNotifier, IDisposable {
     /**
-     * This keeps track of the root adapter factory that delegates to this adapter factory.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the root adapter factory that delegates to this adapter factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ComposedAdapterFactory parentAdapterFactory;
 
     /**
-     * This is used to implement {@link org.eclipse.emf.edit.provider.IChangeNotifier}.
-     * <!-- begin-user-doc -->
+	 * This is used to implement {@link org.eclipse.emf.edit.provider.IChangeNotifier}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected IChangeNotifier changeNotifier = new ChangeNotifier();
 
     /**
-     * This keeps track of all the item providers created, so that they can be {@link #dispose disposed}.
-     * <!-- begin-user-doc -->
+	 * This keeps track of all the item providers created, so that they can be {@link #dispose disposed}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected Disposable disposable = new Disposable();
 
     /**
-     * This keeps track of all the supported types checked by {@link #isFactoryForType isFactoryForType}.
-     * <!-- begin-user-doc -->
+	 * This keeps track of all the supported types checked by {@link #isFactoryForType isFactoryForType}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected Collection<Object> supportedTypes = new ArrayList<Object>();
 
     /**
-     * This constructs an instance.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModelItemProviderAdapterFactory() {
-        supportedTypes.add(IEditingDomainItemProvider.class);
-        supportedTypes.add(IStructuredItemContentProvider.class);
-        supportedTypes.add(ITreeItemContentProvider.class);
-        supportedTypes.add(IItemLabelProvider.class);
-        supportedTypes.add(IItemPropertySource.class);
-    }
+		supportedTypes.add(IEditingDomainItemProvider.class);
+		supportedTypes.add(IStructuredItemContentProvider.class);
+		supportedTypes.add(ITreeItemContentProvider.class);
+		supportedTypes.add(IItemLabelProvider.class);
+		supportedTypes.add(IItemPropertySource.class);
+	}
 
     /**
-     * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fm.FeatureModel} instances.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fm.FeatureModel} instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected FeatureModelItemProvider featureModelItemProvider;
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.FeatureModel}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.FeatureModel}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createFeatureModelAdapter() {
-        if (featureModelItemProvider == null) {
-            featureModelItemProvider = new FeatureModelItemProvider(this);
-        }
+		if (featureModelItemProvider == null) {
+			featureModelItemProvider = new FeatureModelItemProvider(this);
+		}
 
-        return featureModelItemProvider;
-    }
+		return featureModelItemProvider;
+	}
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.Feature}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.Feature}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createFeatureAdapter() {
-        return new FeatureItemProvider(this);
-    }
+		return new FeatureItemProvider(this);
+	}
 
     /**
-     * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fm.Group} instances.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fm.Group} instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected GroupItemProvider groupItemProvider;
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.Group}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.Group}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createGroupAdapter() {
-        if (groupItemProvider == null) {
-            groupItemProvider = new GroupItemProvider(this);
-        }
+		if (groupItemProvider == null) {
+			groupItemProvider = new GroupItemProvider(this);
+		}
 
-        return groupItemProvider;
-    }
+		return groupItemProvider;
+	}
 
     /**
-     * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fm.Attribute} instances.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fm.Attribute} instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected AttributeItemProvider attributeItemProvider;
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.Attribute}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.Attribute}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createAttributeAdapter() {
-        if (attributeItemProvider == null) {
-            attributeItemProvider = new AttributeItemProvider(this);
-        }
+		if (attributeItemProvider == null) {
+			attributeItemProvider = new AttributeItemProvider(this);
+		}
 
-        return attributeItemProvider;
-    }
+		return attributeItemProvider;
+	}
 
     /**
-     * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fm.Constraint} instances.
-     * <!-- begin-user-doc -->
+	 * This keeps track of the one adapter used for all {@link cz.zcu.yafmt.model.fm.Constraint} instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ConstraintItemProvider constraintItemProvider;
 
     /**
-     * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.Constraint}.
-     * <!-- begin-user-doc -->
+	 * This creates an adapter for a {@link cz.zcu.yafmt.model.fm.Constraint}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter createConstraintAdapter() {
-        if (constraintItemProvider == null) {
-            constraintItemProvider = new ConstraintItemProvider(this);
-        }
+		if (constraintItemProvider == null) {
+			constraintItemProvider = new ConstraintItemProvider(this);
+		}
 
-        return constraintItemProvider;
-    }
+		return constraintItemProvider;
+	}
 
     /**
-     * This returns the root adapter factory that contains this factory.
-     * <!-- begin-user-doc -->
+	 * This returns the root adapter factory that contains this factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public ComposeableAdapterFactory getRootAdapterFactory() {
-        return parentAdapterFactory == null ? this : parentAdapterFactory.getRootAdapterFactory();
-    }
+		return parentAdapterFactory == null ? this : parentAdapterFactory.getRootAdapterFactory();
+	}
 
     /**
-     * This sets the composed adapter factory that contains this factory.
-     * <!-- begin-user-doc -->
+	 * This sets the composed adapter factory that contains this factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setParentAdapterFactory(ComposedAdapterFactory parentAdapterFactory) {
-        this.parentAdapterFactory = parentAdapterFactory;
-    }
+		this.parentAdapterFactory = parentAdapterFactory;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean isFactoryForType(Object type) {
-        return supportedTypes.contains(type) || super.isFactoryForType(type);
-    }
+		return supportedTypes.contains(type) || super.isFactoryForType(type);
+	}
 
     /**
-     * This implementation substitutes the factory itself as the key for the adapter.
-     * <!-- begin-user-doc -->
+	 * This implementation substitutes the factory itself as the key for the adapter.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Adapter adapt(Notifier notifier, Object type) {
-        return super.adapt(notifier, this);
-    }
+		return super.adapt(notifier, this);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object adapt(Object object, Object type) {
-        if (isFactoryForType(type)) {
-            Object adapter = super.adapt(object, type);
-            if (!(type instanceof Class<?>) || (((Class<?>)type).isInstance(adapter))) {
-                return adapter;
-            }
-        }
+		if (isFactoryForType(type)) {
+			Object adapter = super.adapt(object, type);
+			if (!(type instanceof Class<?>) || (((Class<?>)type).isInstance(adapter))) {
+				return adapter;
+			}
+		}
 
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Associates an adapter with a notifier via the base implementation, then records it to ensure it will be disposed.
-     * <!-- begin-user-doc -->
+	 * Associates an adapter with a notifier via the base implementation, then records it to ensure it will be disposed.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void associate(Adapter adapter, Notifier target) {
-        super.associate(adapter, target);
-        if (adapter != null) {
-            disposable.add(adapter);
-        }
-    }
+		super.associate(adapter, target);
+		if (adapter != null) {
+			disposable.add(adapter);
+		}
+	}
 
     /**
-     * This adds a listener.
-     * <!-- begin-user-doc -->
+	 * This adds a listener.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void addListener(INotifyChangedListener notifyChangedListener) {
-        changeNotifier.addListener(notifyChangedListener);
-    }
+		changeNotifier.addListener(notifyChangedListener);
+	}
 
     /**
-     * This removes a listener.
-     * <!-- begin-user-doc -->
+	 * This removes a listener.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void removeListener(INotifyChangedListener notifyChangedListener) {
-        changeNotifier.removeListener(notifyChangedListener);
-    }
+		changeNotifier.removeListener(notifyChangedListener);
+	}
 
     /**
-     * This delegates to {@link #changeNotifier} and to {@link #parentAdapterFactory}.
-     * <!-- begin-user-doc -->
+	 * This delegates to {@link #changeNotifier} and to {@link #parentAdapterFactory}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void fireNotifyChanged(Notification notification) {
-        changeNotifier.fireNotifyChanged(notification);
+		changeNotifier.fireNotifyChanged(notification);
 
-        if (parentAdapterFactory != null) {
-            parentAdapterFactory.fireNotifyChanged(notification);
-        }
-    }
+		if (parentAdapterFactory != null) {
+			parentAdapterFactory.fireNotifyChanged(notification);
+		}
+	}
 
     /**
-     * This disposes all of the item providers created by this factory. 
-     * <!-- begin-user-doc -->
+	 * This disposes all of the item providers created by this factory. 
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void dispose() {
-        disposable.dispose();
-    }
+		disposable.dispose();
+	}
 
 }

--- a/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/GroupItemProvider.java
+++ b/cz.zcu.yafmt.model.edit/src/cz/zcu/yafmt/model/fm/provider/GroupItemProvider.java
@@ -44,151 +44,151 @@ public class GroupItemProvider
         IItemLabelProvider,
         IItemPropertySource {
     /**
-     * This constructs an instance from a factory and a notifier.
-     * <!-- begin-user-doc -->
+	 * This constructs an instance from a factory and a notifier.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public GroupItemProvider(AdapterFactory adapterFactory) {
-        super(adapterFactory);
-    }
+		super(adapterFactory);
+	}
 
     /**
-     * This returns the property descriptors for the adapted class.
-     * <!-- begin-user-doc -->
+	 * This returns the property descriptors for the adapted class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public List<IItemPropertyDescriptor> getPropertyDescriptors(Object object) {
-        if (itemPropertyDescriptors == null) {
-            super.getPropertyDescriptors(object);
+		if (itemPropertyDescriptors == null) {
+			super.getPropertyDescriptors(object);
 
-            addLowerPropertyDescriptor(object);
-            addUpperPropertyDescriptor(object);
-            addDescriptionPropertyDescriptor(object);
-            addCommentPropertyDescriptor(object);
-        }
-        return itemPropertyDescriptors;
-    }
+			addLowerPropertyDescriptor(object);
+			addUpperPropertyDescriptor(object);
+			addDescriptionPropertyDescriptor(object);
+			addCommentPropertyDescriptor(object);
+		}
+		return itemPropertyDescriptors;
+	}
 
     /**
-     * This adds a property descriptor for the Lower feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Lower feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addLowerPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Group_lower_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Group_lower_feature", "_UI_Group_type"),
-                 FeatureModelPackage.Literals.GROUP__LOWER,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Group_lower_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Group_lower_feature", "_UI_Group_type"),
+				 FeatureModelPackage.Literals.GROUP__LOWER,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Upper feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Upper feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addUpperPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Group_upper_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Group_upper_feature", "_UI_Group_type"),
-                 FeatureModelPackage.Literals.GROUP__UPPER,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Group_upper_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Group_upper_feature", "_UI_Group_type"),
+				 FeatureModelPackage.Literals.GROUP__UPPER,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.INTEGRAL_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Description feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Description feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addDescriptionPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Group_description_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Group_description_feature", "_UI_Group_type"),
-                 FeatureModelPackage.Literals.GROUP__DESCRIPTION,
-                 true,
-                 false,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Group_description_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Group_description_feature", "_UI_Group_type"),
+				 FeatureModelPackage.Literals.GROUP__DESCRIPTION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This adds a property descriptor for the Comment feature.
-     * <!-- begin-user-doc -->
+	 * This adds a property descriptor for the Comment feature.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected void addCommentPropertyDescriptor(Object object) {
-        itemPropertyDescriptors.add
-            (createItemPropertyDescriptor
-                (((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
-                 getResourceLocator(),
-                 getString("_UI_Group_comment_feature"),
-                 getString("_UI_PropertyDescriptor_description", "_UI_Group_comment_feature", "_UI_Group_type"),
-                 FeatureModelPackage.Literals.GROUP__COMMENT,
-                 true,
-                 true,
-                 false,
-                 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-                 null,
-                 null));
-    }
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_Group_comment_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_Group_comment_feature", "_UI_Group_type"),
+				 FeatureModelPackage.Literals.GROUP__COMMENT,
+				 true,
+				 true,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
+				 null));
+	}
 
     /**
-     * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
-     * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
-     * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
-     * <!-- begin-user-doc -->
+	 * This specifies how to implement {@link #getChildren} and is used to deduce an appropriate feature for an
+	 * {@link org.eclipse.emf.edit.command.AddCommand}, {@link org.eclipse.emf.edit.command.RemoveCommand} or
+	 * {@link org.eclipse.emf.edit.command.MoveCommand} in {@link #createCommand}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Collection<? extends EStructuralFeature> getChildrenFeatures(Object object) {
-        if (childrenFeatures == null) {
-            super.getChildrenFeatures(object);
-            childrenFeatures.add(FeatureModelPackage.Literals.GROUP__FEATURES);
-        }
-        return childrenFeatures;
-    }
+		if (childrenFeatures == null) {
+			super.getChildrenFeatures(object);
+			childrenFeatures.add(FeatureModelPackage.Literals.GROUP__FEATURES);
+		}
+		return childrenFeatures;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EStructuralFeature getChildFeature(Object object, Object child) {
-        // Check the type of the specified child object and return the proper feature to use for
-        // adding (see {@link AddCommand}) it as a child.
+		// Check the type of the specified child object and return the proper feature to use for
+		// adding (see {@link AddCommand}) it as a child.
 
-        return super.getChildFeature(object, child);
-    }
+		return super.getChildFeature(object, child);
+	}
 
     /**
      * This returns Group.gif.
@@ -223,58 +223,58 @@ public class GroupItemProvider
     }
 
     /**
-     * This handles model notifications by calling {@link #updateChildren} to update any cached
-     * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
-     * <!-- begin-user-doc -->
+	 * This handles model notifications by calling {@link #updateChildren} to update any cached
+	 * children and by creating a viewer notification, which it passes to {@link #fireNotifyChanged}.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void notifyChanged(Notification notification) {
-        updateChildren(notification);
+		updateChildren(notification);
 
-        switch (notification.getFeatureID(Group.class)) {
-            case FeatureModelPackage.GROUP__LOWER:
-            case FeatureModelPackage.GROUP__UPPER:
-            case FeatureModelPackage.GROUP__DESCRIPTION:
-            case FeatureModelPackage.GROUP__COMMENT:
-            case FeatureModelPackage.GROUP__XOR:
-            case FeatureModelPackage.GROUP__OR:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-                return;
-            case FeatureModelPackage.GROUP__FEATURES:
-                fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
-                return;
-        }
-        super.notifyChanged(notification);
-    }
+		switch (notification.getFeatureID(Group.class)) {
+			case FeatureModelPackage.GROUP__LOWER:
+			case FeatureModelPackage.GROUP__UPPER:
+			case FeatureModelPackage.GROUP__DESCRIPTION:
+			case FeatureModelPackage.GROUP__COMMENT:
+			case FeatureModelPackage.GROUP__XOR:
+			case FeatureModelPackage.GROUP__OR:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+				return;
+			case FeatureModelPackage.GROUP__FEATURES:
+				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
+				return;
+		}
+		super.notifyChanged(notification);
+	}
 
     /**
-     * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
-     * that can be created under this object.
-     * <!-- begin-user-doc -->
+	 * This adds {@link org.eclipse.emf.edit.command.CommandParameter}s describing the children
+	 * that can be created under this object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected void collectNewChildDescriptors(Collection<Object> newChildDescriptors, Object object) {
-        super.collectNewChildDescriptors(newChildDescriptors, object);
+		super.collectNewChildDescriptors(newChildDescriptors, object);
 
-        newChildDescriptors.add
-            (createChildParameter
-                (FeatureModelPackage.Literals.GROUP__FEATURES,
-                 FeatureModelFactory.eINSTANCE.createFeature()));
-    }
+		newChildDescriptors.add
+			(createChildParameter
+				(FeatureModelPackage.Literals.GROUP__FEATURES,
+				 FeatureModelFactory.eINSTANCE.createFeature()));
+	}
 
     /**
-     * Return the resource locator for this item provider's resources.
-     * <!-- begin-user-doc -->
+	 * Return the resource locator for this item provider's resources.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public ResourceLocator getResourceLocator() {
-        return FeatureModelEditPlugin.INSTANCE;
-    }
+		return FeatureModelEditPlugin.INSTANCE;
+	}
 
 }

--- a/cz.zcu.yafmt.model/META-INF/MANIFEST.MF
+++ b/cz.zcu.yafmt.model/META-INF/MANIFEST.MF
@@ -11,8 +11,10 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.8.0",
  org.eclipse.emf.ecore.xmi;bundle-version="2.8.1"
 Export-Package: cz.zcu.yafmt.model,
  cz.zcu.yafmt.model.fc,
+ cz.zcu.yafmt.model.fc.impl,
  cz.zcu.yafmt.model.fc.util,
  cz.zcu.yafmt.model.fm,
+ cz.zcu.yafmt.model.fm.impl,
  cz.zcu.yafmt.model.fm.util
 Bundle-Vendor: %providerName
 Bundle-Activator: cz.zcu.yafmt.model.FeatureModelPlugin$Implementation

--- a/cz.zcu.yafmt.model/model/FeatureModel.ecore
+++ b/cz.zcu.yafmt.model/model/FeatureModel.ecore
@@ -78,7 +78,8 @@
         iD="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="type" lowerBound="1" eType="#//AttributeType"
-        defaultValueLiteral="BOOLEAN"/>
+        defaultValueLiteral="boolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="description" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="comment" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="feature" lowerBound="1"

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/FeatureModelPlugin.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/FeatureModelPlugin.java
@@ -17,60 +17,60 @@ import cz.zcu.yafmt.model.fm.util.FeatureModelUtil;
 public final class FeatureModelPlugin extends EMFPlugin {
         
     /**
-     * Keep track of the singleton.
-     * <!-- begin-user-doc -->
+	 * Keep track of the singleton.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public static final FeatureModelPlugin INSTANCE = new FeatureModelPlugin();
 
     /**
-     * Keep track of the singleton.
-     * <!-- begin-user-doc -->
+	 * Keep track of the singleton.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private static Implementation plugin;
 
     /**
-     * Create the instance.
-     * <!-- begin-user-doc -->
+	 * Create the instance.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModelPlugin() {
-        super(new ResourceLocator [] {});
-    }
+		super(new ResourceLocator [] {});
+	}
 
     /**
-     * Returns the singleton instance of the Eclipse plugin.
-     * <!-- begin-user-doc -->
+	 * Returns the singleton instance of the Eclipse plugin.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the singleton instance.
-     * @generated
-     */
+	 * @return the singleton instance.
+	 * @generated
+	 */
     @Override
     public ResourceLocator getPluginResourceLocator() {
-        return plugin;
-    }
+		return plugin;
+	}
 
     /**
-     * Returns the singleton instance of the Eclipse plugin.
-     * <!-- begin-user-doc -->
+	 * Returns the singleton instance of the Eclipse plugin.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the singleton instance.
-     * @generated
-     */
+	 * @return the singleton instance.
+	 * @generated
+	 */
     public static Implementation getPlugin() {
-        return plugin;
-    }
+		return plugin;
+	}
 
     /**
-     * The actual implementation of the Eclipse <b>Plugin</b>.
-     * <!-- begin-user-doc -->
+	 * The actual implementation of the Eclipse <b>Plugin</b>.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public static class Implementation extends EclipsePlugin {
         /**
          * Creates an instance.

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/AttributeValue.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/AttributeValue.java
@@ -13,6 +13,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.AttributeValue#getId <em>Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.AttributeValue#getName <em>Name</em>}</li>
@@ -21,7 +22,6 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link cz.zcu.yafmt.model.fc.AttributeValue#getSelection <em>Selection</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.AttributeValue#getAttribute <em>Attribute</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue()
  * @model abstract="true"
@@ -29,117 +29,117 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface AttributeValue extends EObject {
     /**
-     * Returns the value of the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Id</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Id</em>' attribute.
-     * @see #setId(String)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Id()
-     * @model required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Id</em>' attribute.
+	 * @see #setId(String)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Id()
+	 * @model required="true"
+	 * @generated
+	 */
     String getId();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.AttributeValue#getId <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.AttributeValue#getId <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Id</em>' attribute.
-     * @see #getId()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Id</em>' attribute.
+	 * @see #getId()
+	 * @generated
+	 */
     void setId(String value);
 
     /**
-     * Returns the value of the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Name</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Name</em>' attribute.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Name()
-     * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Name</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Name()
+	 * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     String getName();
 
     /**
-     * Returns the value of the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Description</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Description</em>' attribute.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Description()
-     * @model transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Description</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Description()
+	 * @model transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     String getDescription();
 
     /**
-     * Returns the value of the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Comment</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Comment</em>' attribute.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Comment()
-     * @model transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Comment</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Comment()
+	 * @model transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     String getComment();
 
     /**
-     * Returns the value of the '<em><b>Selection</b></em>' container reference.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fc.Selection#getValues <em>Values</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Selection</b></em>' container reference.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fc.Selection#getValues <em>Values</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Selection</em>' container reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Selection</em>' container reference.
-     * @see #setSelection(Selection)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Selection()
-     * @see cz.zcu.yafmt.model.fc.Selection#getValues
-     * @model opposite="values" required="true" transient="false"
-     * @generated
-     */
+	 * @return the value of the '<em>Selection</em>' container reference.
+	 * @see #setSelection(Selection)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Selection()
+	 * @see cz.zcu.yafmt.model.fc.Selection#getValues
+	 * @model opposite="values" required="true" transient="false"
+	 * @generated
+	 */
     Selection getSelection();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.AttributeValue#getSelection <em>Selection</em>}' container reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.AttributeValue#getSelection <em>Selection</em>}' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Selection</em>' container reference.
-     * @see #getSelection()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Selection</em>' container reference.
+	 * @see #getSelection()
+	 * @generated
+	 */
     void setSelection(Selection value);
 
     /**
-     * Returns the value of the '<em><b>Attribute</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Attribute</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Attribute</em>' reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Attribute</em>' reference.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Attribute()
-     * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Attribute</em>' reference.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getAttributeValue_Attribute()
+	 * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     Attribute getAttribute();
 
 } // AttributeValue

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/BooleanValue.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/BooleanValue.java
@@ -10,10 +10,10 @@ package cz.zcu.yafmt.model.fc;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.BooleanValue#isValue <em>Value</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getBooleanValue()
  * @model
@@ -21,30 +21,30 @@ package cz.zcu.yafmt.model.fc;
  */
 public interface BooleanValue extends AttributeValue {
     /**
-     * Returns the value of the '<em><b>Value</b></em>' attribute.
-     * The default value is <code>"false"</code>.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Value</b></em>' attribute.
+	 * The default value is <code>"false"</code>.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Value</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Value</em>' attribute.
-     * @see #setValue(boolean)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getBooleanValue_Value()
-     * @model default="false" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Value</em>' attribute.
+	 * @see #setValue(boolean)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getBooleanValue_Value()
+	 * @model default="false" required="true"
+	 * @generated
+	 */
     boolean isValue();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.BooleanValue#isValue <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.BooleanValue#isValue <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Value</em>' attribute.
-     * @see #isValue()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Value</em>' attribute.
+	 * @see #isValue()
+	 * @generated
+	 */
     void setValue(boolean value);
 
 } // BooleanValue

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/DoubleValue.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/DoubleValue.java
@@ -10,10 +10,10 @@ package cz.zcu.yafmt.model.fc;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.DoubleValue#getValue <em>Value</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getDoubleValue()
  * @model
@@ -21,30 +21,30 @@ package cz.zcu.yafmt.model.fc;
  */
 public interface DoubleValue extends AttributeValue {
     /**
-     * Returns the value of the '<em><b>Value</b></em>' attribute.
-     * The default value is <code>"0.0"</code>.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Value</b></em>' attribute.
+	 * The default value is <code>"0.0"</code>.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Value</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Value</em>' attribute.
-     * @see #setValue(double)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getDoubleValue_Value()
-     * @model default="0.0" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Value</em>' attribute.
+	 * @see #setValue(double)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getDoubleValue_Value()
+	 * @model default="0.0" required="true"
+	 * @generated
+	 */
     double getValue();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.DoubleValue#getValue <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.DoubleValue#getValue <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Value</em>' attribute.
-     * @see #getValue()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Value</em>' attribute.
+	 * @see #getValue()
+	 * @generated
+	 */
     void setValue(double value);
 
 } // DoubleValue

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/FeatureConfiguration.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/FeatureConfiguration.java
@@ -15,6 +15,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getName <em>Name</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getVersion <em>Version</em>}</li>
@@ -24,7 +25,6 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModelCopy <em>Feature Model Copy</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getRoot <em>Root</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration()
  * @model
@@ -32,193 +32,193 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface FeatureConfiguration extends EObject {
     /**
-     * Returns the value of the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Name</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Name</em>' attribute.
-     * @see #setName(String)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Name()
-     * @model required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Name</em>' attribute.
+	 * @see #setName(String)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Name()
+	 * @model required="true"
+	 * @generated
+	 */
     String getName();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getName <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getName <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Name</em>' attribute.
-     * @see #getName()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Name</em>' attribute.
+	 * @see #getName()
+	 * @generated
+	 */
     void setName(String value);
 
     /**
-     * Returns the value of the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Description</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Description</em>' attribute.
-     * @see #setDescription(String)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Description()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Description</em>' attribute.
+	 * @see #setDescription(String)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Description()
+	 * @model
+	 * @generated
+	 */
     String getDescription();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getDescription <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getDescription <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Description</em>' attribute.
-     * @see #getDescription()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Description</em>' attribute.
+	 * @see #getDescription()
+	 * @generated
+	 */
     void setDescription(String value);
 
     /**
-     * Returns the value of the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Comment</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Comment</em>' attribute.
-     * @see #setComment(String)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Comment()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Comment</em>' attribute.
+	 * @see #setComment(String)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Comment()
+	 * @model
+	 * @generated
+	 */
     String getComment();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getComment <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getComment <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Comment</em>' attribute.
-     * @see #getComment()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Comment</em>' attribute.
+	 * @see #getComment()
+	 * @generated
+	 */
     void setComment(String value);
 
     /**
-     * Returns the value of the '<em><b>Version</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Version</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Version</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Version</em>' attribute.
-     * @see #setVersion(String)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Version()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Version</em>' attribute.
+	 * @see #setVersion(String)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Version()
+	 * @model
+	 * @generated
+	 */
     String getVersion();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getVersion <em>Version</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getVersion <em>Version</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Version</em>' attribute.
-     * @see #getVersion()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Version</em>' attribute.
+	 * @see #getVersion()
+	 * @generated
+	 */
     void setVersion(String value);
 
     /**
-     * Returns the value of the '<em><b>Feature Model</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Feature Model</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Feature Model</em>' reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Feature Model</em>' reference.
-     * @see #setFeatureModel(FeatureModel)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_FeatureModel()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Feature Model</em>' reference.
+	 * @see #setFeatureModel(FeatureModel)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_FeatureModel()
+	 * @model
+	 * @generated
+	 */
     FeatureModel getFeatureModel();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModel <em>Feature Model</em>}' reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModel <em>Feature Model</em>}' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Feature Model</em>' reference.
-     * @see #getFeatureModel()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Feature Model</em>' reference.
+	 * @see #getFeatureModel()
+	 * @generated
+	 */
     void setFeatureModel(FeatureModel value);
 
     /**
-     * Returns the value of the '<em><b>Feature Model Copy</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Feature Model Copy</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Feature Model Copy</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Feature Model Copy</em>' containment reference.
-     * @see #setFeatureModelCopy(FeatureModel)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_FeatureModelCopy()
-     * @model containment="true" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Feature Model Copy</em>' containment reference.
+	 * @see #setFeatureModelCopy(FeatureModel)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_FeatureModelCopy()
+	 * @model containment="true" required="true"
+	 * @generated
+	 */
     FeatureModel getFeatureModelCopy();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModelCopy <em>Feature Model Copy</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModelCopy <em>Feature Model Copy</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Feature Model Copy</em>' containment reference.
-     * @see #getFeatureModelCopy()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Feature Model Copy</em>' containment reference.
+	 * @see #getFeatureModelCopy()
+	 * @generated
+	 */
     void setFeatureModelCopy(FeatureModel value);
 
     /**
-     * Returns the value of the '<em><b>Root</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Root</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Root</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Root</em>' containment reference.
-     * @see #setRoot(Selection)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Root()
-     * @model containment="true" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Root</em>' containment reference.
+	 * @see #setRoot(Selection)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getFeatureConfiguration_Root()
+	 * @model containment="true" required="true"
+	 * @generated
+	 */
     Selection getRoot();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getRoot <em>Root</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getRoot <em>Root</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Root</em>' containment reference.
-     * @see #getRoot()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Root</em>' containment reference.
+	 * @see #getRoot()
+	 * @generated
+	 */
     void setRoot(Selection value);
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @model many="false"
-     * @generated
-     */
+	 * @model many="false"
+	 * @generated
+	 */
     EList<Selection> getSelectionsById(String id);
 
 } // FeatureConfiguration

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/FeatureConfigurationFactory.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/FeatureConfigurationFactory.java
@@ -14,74 +14,74 @@ import org.eclipse.emf.ecore.EFactory;
  */
 public interface FeatureConfigurationFactory extends EFactory {
     /**
-     * The singleton instance of the factory.
-     * <!-- begin-user-doc -->
+	 * The singleton instance of the factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     FeatureConfigurationFactory eINSTANCE = cz.zcu.yafmt.model.fc.impl.FeatureConfigurationFactoryImpl.init();
 
     /**
-     * Returns a new object of class '<em>Feature Configuration</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Feature Configuration</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Feature Configuration</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Feature Configuration</em>'.
+	 * @generated
+	 */
     FeatureConfiguration createFeatureConfiguration();
 
     /**
-     * Returns a new object of class '<em>Selection</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Selection</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Selection</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Selection</em>'.
+	 * @generated
+	 */
     Selection createSelection();
 
     /**
-     * Returns a new object of class '<em>Boolean Value</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Boolean Value</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Boolean Value</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Boolean Value</em>'.
+	 * @generated
+	 */
     BooleanValue createBooleanValue();
 
     /**
-     * Returns a new object of class '<em>Integer Value</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Integer Value</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Integer Value</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Integer Value</em>'.
+	 * @generated
+	 */
     IntegerValue createIntegerValue();
 
     /**
-     * Returns a new object of class '<em>Double Value</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Double Value</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Double Value</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Double Value</em>'.
+	 * @generated
+	 */
     DoubleValue createDoubleValue();
 
     /**
-     * Returns a new object of class '<em>String Value</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>String Value</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>String Value</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>String Value</em>'.
+	 * @generated
+	 */
     StringValue createStringValue();
 
     /**
-     * Returns the package supported by this factory.
-     * <!-- begin-user-doc -->
+	 * Returns the package supported by this factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the package supported by this factory.
-     * @generated
-     */
+	 * @return the package supported by this factory.
+	 * @generated
+	 */
     FeatureConfigurationPackage getFeatureConfigurationPackage();
 
 } //FeatureConfigurationFactory

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/FeatureConfigurationPackage.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/FeatureConfigurationPackage.java
@@ -24,1048 +24,1048 @@ import org.eclipse.emf.ecore.EReference;
  */
 public interface FeatureConfigurationPackage extends EPackage {
     /**
-     * The package name.
-     * <!-- begin-user-doc -->
+	 * The package name.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     String eNAME = "fc";
 
     /**
-     * The package namespace URI.
-     * <!-- begin-user-doc -->
+	 * The package namespace URI.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     String eNS_URI = "http://zcu.cz/yafmt/model/fc";
 
     /**
-     * The package namespace name.
-     * <!-- begin-user-doc -->
+	 * The package namespace name.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     String eNS_PREFIX = "fc";
 
     /**
-     * The singleton instance of the package.
-     * <!-- begin-user-doc -->
+	 * The singleton instance of the package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     FeatureConfigurationPackage eINSTANCE = cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl.init();
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl <em>Feature Configuration</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl <em>Feature Configuration</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl
-     * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getFeatureConfiguration()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl
+	 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getFeatureConfiguration()
+	 * @generated
+	 */
     int FEATURE_CONFIGURATION = 0;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_CONFIGURATION__NAME = 0;
 
     /**
-     * The feature id for the '<em><b>Version</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Version</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_CONFIGURATION__VERSION = 1;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_CONFIGURATION__DESCRIPTION = 2;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_CONFIGURATION__COMMENT = 3;
 
     /**
-     * The feature id for the '<em><b>Feature Model</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Feature Model</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_CONFIGURATION__FEATURE_MODEL = 4;
 
     /**
-     * The feature id for the '<em><b>Feature Model Copy</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Feature Model Copy</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_CONFIGURATION__FEATURE_MODEL_COPY = 5;
 
     /**
-     * The feature id for the '<em><b>Root</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Root</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_CONFIGURATION__ROOT = 6;
 
     /**
-     * The number of structural features of the '<em>Feature Configuration</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Feature Configuration</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_CONFIGURATION_FEATURE_COUNT = 7;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.SelectionImpl <em>Selection</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.SelectionImpl <em>Selection</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fc.impl.SelectionImpl
-     * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getSelection()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fc.impl.SelectionImpl
+	 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getSelection()
+	 * @generated
+	 */
     int SELECTION = 1;
 
     /**
-     * The feature id for the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__ID = 0;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__NAME = 1;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__DESCRIPTION = 2;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__COMMENT = 3;
 
     /**
-     * The feature id for the '<em><b>Parent</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Parent</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__PARENT = 4;
 
     /**
-     * The feature id for the '<em><b>Root</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Root</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__ROOT = 5;
 
     /**
-     * The feature id for the '<em><b>Present</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Present</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__PRESENT = 6;
 
     /**
-     * The feature id for the '<em><b>Enabled</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Enabled</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__ENABLED = 7;
 
     /**
-     * The feature id for the '<em><b>Values</b></em>' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Values</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__VALUES = 8;
 
     /**
-     * The feature id for the '<em><b>Selections</b></em>' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Selections</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__SELECTIONS = 9;
 
     /**
-     * The feature id for the '<em><b>Feature Configuration</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Feature Configuration</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__FEATURE_CONFIGURATION = 10;
 
     /**
-     * The feature id for the '<em><b>Feature</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Feature</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION__FEATURE = 11;
 
     /**
-     * The number of structural features of the '<em>Selection</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Selection</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int SELECTION_FEATURE_COUNT = 12;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.AttributeValueImpl <em>Attribute Value</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.AttributeValueImpl <em>Attribute Value</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fc.impl.AttributeValueImpl
-     * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getAttributeValue()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fc.impl.AttributeValueImpl
+	 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getAttributeValue()
+	 * @generated
+	 */
     int ATTRIBUTE_VALUE = 2;
 
     /**
-     * The feature id for the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE_VALUE__ID = 0;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE_VALUE__NAME = 1;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE_VALUE__DESCRIPTION = 2;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE_VALUE__COMMENT = 3;
 
     /**
-     * The feature id for the '<em><b>Selection</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Selection</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE_VALUE__SELECTION = 4;
 
     /**
-     * The feature id for the '<em><b>Attribute</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Attribute</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE_VALUE__ATTRIBUTE = 5;
 
     /**
-     * The number of structural features of the '<em>Attribute Value</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Attribute Value</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE_VALUE_FEATURE_COUNT = 6;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.BooleanValueImpl <em>Boolean Value</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.BooleanValueImpl <em>Boolean Value</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fc.impl.BooleanValueImpl
-     * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getBooleanValue()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fc.impl.BooleanValueImpl
+	 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getBooleanValue()
+	 * @generated
+	 */
     int BOOLEAN_VALUE = 3;
 
     /**
-     * The feature id for the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int BOOLEAN_VALUE__ID = ATTRIBUTE_VALUE__ID;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int BOOLEAN_VALUE__NAME = ATTRIBUTE_VALUE__NAME;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int BOOLEAN_VALUE__DESCRIPTION = ATTRIBUTE_VALUE__DESCRIPTION;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int BOOLEAN_VALUE__COMMENT = ATTRIBUTE_VALUE__COMMENT;
 
     /**
-     * The feature id for the '<em><b>Selection</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Selection</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int BOOLEAN_VALUE__SELECTION = ATTRIBUTE_VALUE__SELECTION;
 
     /**
-     * The feature id for the '<em><b>Attribute</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Attribute</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int BOOLEAN_VALUE__ATTRIBUTE = ATTRIBUTE_VALUE__ATTRIBUTE;
 
     /**
-     * The feature id for the '<em><b>Value</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int BOOLEAN_VALUE__VALUE = ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
 
     /**
-     * The number of structural features of the '<em>Boolean Value</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Boolean Value</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int BOOLEAN_VALUE_FEATURE_COUNT = ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.IntegerValueImpl <em>Integer Value</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.IntegerValueImpl <em>Integer Value</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fc.impl.IntegerValueImpl
-     * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getIntegerValue()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fc.impl.IntegerValueImpl
+	 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getIntegerValue()
+	 * @generated
+	 */
     int INTEGER_VALUE = 4;
 
     /**
-     * The feature id for the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int INTEGER_VALUE__ID = ATTRIBUTE_VALUE__ID;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int INTEGER_VALUE__NAME = ATTRIBUTE_VALUE__NAME;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int INTEGER_VALUE__DESCRIPTION = ATTRIBUTE_VALUE__DESCRIPTION;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int INTEGER_VALUE__COMMENT = ATTRIBUTE_VALUE__COMMENT;
 
     /**
-     * The feature id for the '<em><b>Selection</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Selection</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int INTEGER_VALUE__SELECTION = ATTRIBUTE_VALUE__SELECTION;
 
     /**
-     * The feature id for the '<em><b>Attribute</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Attribute</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int INTEGER_VALUE__ATTRIBUTE = ATTRIBUTE_VALUE__ATTRIBUTE;
 
     /**
-     * The feature id for the '<em><b>Value</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int INTEGER_VALUE__VALUE = ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
 
     /**
-     * The number of structural features of the '<em>Integer Value</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Integer Value</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int INTEGER_VALUE_FEATURE_COUNT = ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.DoubleValueImpl <em>Double Value</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.DoubleValueImpl <em>Double Value</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fc.impl.DoubleValueImpl
-     * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getDoubleValue()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fc.impl.DoubleValueImpl
+	 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getDoubleValue()
+	 * @generated
+	 */
     int DOUBLE_VALUE = 5;
 
     /**
-     * The feature id for the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DOUBLE_VALUE__ID = ATTRIBUTE_VALUE__ID;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DOUBLE_VALUE__NAME = ATTRIBUTE_VALUE__NAME;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DOUBLE_VALUE__DESCRIPTION = ATTRIBUTE_VALUE__DESCRIPTION;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DOUBLE_VALUE__COMMENT = ATTRIBUTE_VALUE__COMMENT;
 
     /**
-     * The feature id for the '<em><b>Selection</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Selection</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DOUBLE_VALUE__SELECTION = ATTRIBUTE_VALUE__SELECTION;
 
     /**
-     * The feature id for the '<em><b>Attribute</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Attribute</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DOUBLE_VALUE__ATTRIBUTE = ATTRIBUTE_VALUE__ATTRIBUTE;
 
     /**
-     * The feature id for the '<em><b>Value</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DOUBLE_VALUE__VALUE = ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
 
     /**
-     * The number of structural features of the '<em>Double Value</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Double Value</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int DOUBLE_VALUE_FEATURE_COUNT = ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.StringValueImpl <em>String Value</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fc.impl.StringValueImpl <em>String Value</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fc.impl.StringValueImpl
-     * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getStringValue()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fc.impl.StringValueImpl
+	 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getStringValue()
+	 * @generated
+	 */
     int STRING_VALUE = 6;
 
     /**
-     * The feature id for the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int STRING_VALUE__ID = ATTRIBUTE_VALUE__ID;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int STRING_VALUE__NAME = ATTRIBUTE_VALUE__NAME;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int STRING_VALUE__DESCRIPTION = ATTRIBUTE_VALUE__DESCRIPTION;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int STRING_VALUE__COMMENT = ATTRIBUTE_VALUE__COMMENT;
 
     /**
-     * The feature id for the '<em><b>Selection</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Selection</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int STRING_VALUE__SELECTION = ATTRIBUTE_VALUE__SELECTION;
 
     /**
-     * The feature id for the '<em><b>Attribute</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Attribute</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int STRING_VALUE__ATTRIBUTE = ATTRIBUTE_VALUE__ATTRIBUTE;
 
     /**
-     * The feature id for the '<em><b>Value</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int STRING_VALUE__VALUE = ATTRIBUTE_VALUE_FEATURE_COUNT + 0;
 
     /**
-     * The number of structural features of the '<em>String Value</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>String Value</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int STRING_VALUE_FEATURE_COUNT = ATTRIBUTE_VALUE_FEATURE_COUNT + 1;
 
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration <em>Feature Configuration</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration <em>Feature Configuration</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Feature Configuration</em>'.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfiguration
-     * @generated
-     */
+	 * @return the meta object for class '<em>Feature Configuration</em>'.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfiguration
+	 * @generated
+	 */
     EClass getFeatureConfiguration();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getName <em>Name</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getName <em>Name</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Name</em>'.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getName()
-     * @see #getFeatureConfiguration()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Name</em>'.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getName()
+	 * @see #getFeatureConfiguration()
+	 * @generated
+	 */
     EAttribute getFeatureConfiguration_Name();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getDescription <em>Description</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getDescription <em>Description</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Description</em>'.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getDescription()
-     * @see #getFeatureConfiguration()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Description</em>'.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getDescription()
+	 * @see #getFeatureConfiguration()
+	 * @generated
+	 */
     EAttribute getFeatureConfiguration_Description();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getComment <em>Comment</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getComment <em>Comment</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Comment</em>'.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getComment()
-     * @see #getFeatureConfiguration()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Comment</em>'.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getComment()
+	 * @see #getFeatureConfiguration()
+	 * @generated
+	 */
     EAttribute getFeatureConfiguration_Comment();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getVersion <em>Version</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getVersion <em>Version</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Version</em>'.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getVersion()
-     * @see #getFeatureConfiguration()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Version</em>'.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getVersion()
+	 * @see #getFeatureConfiguration()
+	 * @generated
+	 */
     EAttribute getFeatureConfiguration_Version();
 
     /**
-     * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModel <em>Feature Model</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModel <em>Feature Model</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the reference '<em>Feature Model</em>'.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModel()
-     * @see #getFeatureConfiguration()
-     * @generated
-     */
+	 * @return the meta object for the reference '<em>Feature Model</em>'.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModel()
+	 * @see #getFeatureConfiguration()
+	 * @generated
+	 */
     EReference getFeatureConfiguration_FeatureModel();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModelCopy <em>Feature Model Copy</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModelCopy <em>Feature Model Copy</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Feature Model Copy</em>'.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModelCopy()
-     * @see #getFeatureConfiguration()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Feature Model Copy</em>'.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getFeatureModelCopy()
+	 * @see #getFeatureConfiguration()
+	 * @generated
+	 */
     EReference getFeatureConfiguration_FeatureModelCopy();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getRoot <em>Root</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration#getRoot <em>Root</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Root</em>'.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getRoot()
-     * @see #getFeatureConfiguration()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Root</em>'.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfiguration#getRoot()
+	 * @see #getFeatureConfiguration()
+	 * @generated
+	 */
     EReference getFeatureConfiguration_Root();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.Selection <em>Selection</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.Selection <em>Selection</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Selection</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection
-     * @generated
-     */
+	 * @return the meta object for class '<em>Selection</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection
+	 * @generated
+	 */
     EClass getSelection();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#getId <em>Id</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#getId <em>Id</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Id</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#getId()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Id</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#getId()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EAttribute getSelection_Id();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#getName <em>Name</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#getName <em>Name</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Name</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#getName()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Name</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#getName()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EAttribute getSelection_Name();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#getDescription <em>Description</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#getDescription <em>Description</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Description</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#getDescription()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Description</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#getDescription()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EAttribute getSelection_Description();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#getComment <em>Comment</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#getComment <em>Comment</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Comment</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#getComment()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Comment</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#getComment()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EAttribute getSelection_Comment();
 
     /**
-     * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fc.Selection#getParent <em>Parent</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fc.Selection#getParent <em>Parent</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the container reference '<em>Parent</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#getParent()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the container reference '<em>Parent</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#getParent()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EReference getSelection_Parent();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#isRoot <em>Root</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#isRoot <em>Root</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Root</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#isRoot()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Root</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#isRoot()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EAttribute getSelection_Root();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#isPresent <em>Present</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#isPresent <em>Present</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Present</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#isPresent()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Present</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#isPresent()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EAttribute getSelection_Present();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#isEnabled <em>Enabled</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.Selection#isEnabled <em>Enabled</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Enabled</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#isEnabled()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Enabled</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#isEnabled()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EAttribute getSelection_Enabled();
 
     /**
-     * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fc.Selection#getSelections <em>Selections</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fc.Selection#getSelections <em>Selections</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference list '<em>Selections</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#getSelections()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the containment reference list '<em>Selections</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#getSelections()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EReference getSelection_Selections();
 
     /**
-     * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fc.Selection#getValues <em>Values</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fc.Selection#getValues <em>Values</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference list '<em>Values</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#getValues()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the containment reference list '<em>Values</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#getValues()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EReference getSelection_Values();
 
     /**
-     * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fc.Selection#getFeatureConfiguration <em>Feature Configuration</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fc.Selection#getFeatureConfiguration <em>Feature Configuration</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the reference '<em>Feature Configuration</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#getFeatureConfiguration()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the reference '<em>Feature Configuration</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#getFeatureConfiguration()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EReference getSelection_FeatureConfiguration();
 
     /**
-     * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fc.Selection#getFeature <em>Feature</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fc.Selection#getFeature <em>Feature</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the reference '<em>Feature</em>'.
-     * @see cz.zcu.yafmt.model.fc.Selection#getFeature()
-     * @see #getSelection()
-     * @generated
-     */
+	 * @return the meta object for the reference '<em>Feature</em>'.
+	 * @see cz.zcu.yafmt.model.fc.Selection#getFeature()
+	 * @see #getSelection()
+	 * @generated
+	 */
     EReference getSelection_Feature();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.AttributeValue <em>Attribute Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.AttributeValue <em>Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Attribute Value</em>'.
-     * @see cz.zcu.yafmt.model.fc.AttributeValue
-     * @generated
-     */
+	 * @return the meta object for class '<em>Attribute Value</em>'.
+	 * @see cz.zcu.yafmt.model.fc.AttributeValue
+	 * @generated
+	 */
     EClass getAttributeValue();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.AttributeValue#getId <em>Id</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.AttributeValue#getId <em>Id</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Id</em>'.
-     * @see cz.zcu.yafmt.model.fc.AttributeValue#getId()
-     * @see #getAttributeValue()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Id</em>'.
+	 * @see cz.zcu.yafmt.model.fc.AttributeValue#getId()
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
     EAttribute getAttributeValue_Id();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.AttributeValue#getName <em>Name</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.AttributeValue#getName <em>Name</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Name</em>'.
-     * @see cz.zcu.yafmt.model.fc.AttributeValue#getName()
-     * @see #getAttributeValue()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Name</em>'.
+	 * @see cz.zcu.yafmt.model.fc.AttributeValue#getName()
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
     EAttribute getAttributeValue_Name();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.AttributeValue#getDescription <em>Description</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.AttributeValue#getDescription <em>Description</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Description</em>'.
-     * @see cz.zcu.yafmt.model.fc.AttributeValue#getDescription()
-     * @see #getAttributeValue()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Description</em>'.
+	 * @see cz.zcu.yafmt.model.fc.AttributeValue#getDescription()
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
     EAttribute getAttributeValue_Description();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.AttributeValue#getComment <em>Comment</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.AttributeValue#getComment <em>Comment</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Comment</em>'.
-     * @see cz.zcu.yafmt.model.fc.AttributeValue#getComment()
-     * @see #getAttributeValue()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Comment</em>'.
+	 * @see cz.zcu.yafmt.model.fc.AttributeValue#getComment()
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
     EAttribute getAttributeValue_Comment();
 
     /**
-     * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fc.AttributeValue#getSelection <em>Selection</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fc.AttributeValue#getSelection <em>Selection</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the container reference '<em>Selection</em>'.
-     * @see cz.zcu.yafmt.model.fc.AttributeValue#getSelection()
-     * @see #getAttributeValue()
-     * @generated
-     */
+	 * @return the meta object for the container reference '<em>Selection</em>'.
+	 * @see cz.zcu.yafmt.model.fc.AttributeValue#getSelection()
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
     EReference getAttributeValue_Selection();
 
     /**
-     * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fc.AttributeValue#getAttribute <em>Attribute</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fc.AttributeValue#getAttribute <em>Attribute</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the reference '<em>Attribute</em>'.
-     * @see cz.zcu.yafmt.model.fc.AttributeValue#getAttribute()
-     * @see #getAttributeValue()
-     * @generated
-     */
+	 * @return the meta object for the reference '<em>Attribute</em>'.
+	 * @see cz.zcu.yafmt.model.fc.AttributeValue#getAttribute()
+	 * @see #getAttributeValue()
+	 * @generated
+	 */
     EReference getAttributeValue_Attribute();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.BooleanValue <em>Boolean Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.BooleanValue <em>Boolean Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Boolean Value</em>'.
-     * @see cz.zcu.yafmt.model.fc.BooleanValue
-     * @generated
-     */
+	 * @return the meta object for class '<em>Boolean Value</em>'.
+	 * @see cz.zcu.yafmt.model.fc.BooleanValue
+	 * @generated
+	 */
     EClass getBooleanValue();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.BooleanValue#isValue <em>Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.BooleanValue#isValue <em>Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Value</em>'.
-     * @see cz.zcu.yafmt.model.fc.BooleanValue#isValue()
-     * @see #getBooleanValue()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Value</em>'.
+	 * @see cz.zcu.yafmt.model.fc.BooleanValue#isValue()
+	 * @see #getBooleanValue()
+	 * @generated
+	 */
     EAttribute getBooleanValue_Value();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.IntegerValue <em>Integer Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.IntegerValue <em>Integer Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Integer Value</em>'.
-     * @see cz.zcu.yafmt.model.fc.IntegerValue
-     * @generated
-     */
+	 * @return the meta object for class '<em>Integer Value</em>'.
+	 * @see cz.zcu.yafmt.model.fc.IntegerValue
+	 * @generated
+	 */
     EClass getIntegerValue();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.IntegerValue#getValue <em>Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.IntegerValue#getValue <em>Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Value</em>'.
-     * @see cz.zcu.yafmt.model.fc.IntegerValue#getValue()
-     * @see #getIntegerValue()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Value</em>'.
+	 * @see cz.zcu.yafmt.model.fc.IntegerValue#getValue()
+	 * @see #getIntegerValue()
+	 * @generated
+	 */
     EAttribute getIntegerValue_Value();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.DoubleValue <em>Double Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.DoubleValue <em>Double Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Double Value</em>'.
-     * @see cz.zcu.yafmt.model.fc.DoubleValue
-     * @generated
-     */
+	 * @return the meta object for class '<em>Double Value</em>'.
+	 * @see cz.zcu.yafmt.model.fc.DoubleValue
+	 * @generated
+	 */
     EClass getDoubleValue();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.DoubleValue#getValue <em>Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.DoubleValue#getValue <em>Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Value</em>'.
-     * @see cz.zcu.yafmt.model.fc.DoubleValue#getValue()
-     * @see #getDoubleValue()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Value</em>'.
+	 * @see cz.zcu.yafmt.model.fc.DoubleValue#getValue()
+	 * @see #getDoubleValue()
+	 * @generated
+	 */
     EAttribute getDoubleValue_Value();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.StringValue <em>String Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fc.StringValue <em>String Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>String Value</em>'.
-     * @see cz.zcu.yafmt.model.fc.StringValue
-     * @generated
-     */
+	 * @return the meta object for class '<em>String Value</em>'.
+	 * @see cz.zcu.yafmt.model.fc.StringValue
+	 * @generated
+	 */
     EClass getStringValue();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.StringValue#getValue <em>Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fc.StringValue#getValue <em>Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Value</em>'.
-     * @see cz.zcu.yafmt.model.fc.StringValue#getValue()
-     * @see #getStringValue()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Value</em>'.
+	 * @see cz.zcu.yafmt.model.fc.StringValue#getValue()
+	 * @see #getStringValue()
+	 * @generated
+	 */
     EAttribute getStringValue_Value();
 
     /**
-     * Returns the factory that creates the instances of the model.
-     * <!-- begin-user-doc -->
+	 * Returns the factory that creates the instances of the model.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the factory that creates the instances of the model.
-     * @generated
-     */
+	 * @return the factory that creates the instances of the model.
+	 * @generated
+	 */
     FeatureConfigurationFactory getFeatureConfigurationFactory();
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * Defines literals for the meta objects that represent
      * <ul>
      *   <li>each class,</li>
@@ -1074,309 +1074,309 @@ public interface FeatureConfigurationPackage extends EPackage {
      *   <li>and each data type</li>
      * </ul>
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     interface Literals {
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl <em>Feature Configuration</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl <em>Feature Configuration</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl
-         * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getFeatureConfiguration()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl
+		 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getFeatureConfiguration()
+		 * @generated
+		 */
         EClass FEATURE_CONFIGURATION = eINSTANCE.getFeatureConfiguration();
 
         /**
-         * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE_CONFIGURATION__NAME = eINSTANCE.getFeatureConfiguration_Name();
 
         /**
-         * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE_CONFIGURATION__DESCRIPTION = eINSTANCE.getFeatureConfiguration_Description();
 
         /**
-         * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE_CONFIGURATION__COMMENT = eINSTANCE.getFeatureConfiguration_Comment();
 
         /**
-         * The meta object literal for the '<em><b>Version</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Version</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE_CONFIGURATION__VERSION = eINSTANCE.getFeatureConfiguration_Version();
 
         /**
-         * The meta object literal for the '<em><b>Feature Model</b></em>' reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Feature Model</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE_CONFIGURATION__FEATURE_MODEL = eINSTANCE.getFeatureConfiguration_FeatureModel();
 
         /**
-         * The meta object literal for the '<em><b>Feature Model Copy</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Feature Model Copy</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE_CONFIGURATION__FEATURE_MODEL_COPY = eINSTANCE.getFeatureConfiguration_FeatureModelCopy();
 
         /**
-         * The meta object literal for the '<em><b>Root</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Root</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE_CONFIGURATION__ROOT = eINSTANCE.getFeatureConfiguration_Root();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.SelectionImpl <em>Selection</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.SelectionImpl <em>Selection</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fc.impl.SelectionImpl
-         * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getSelection()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fc.impl.SelectionImpl
+		 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getSelection()
+		 * @generated
+		 */
         EClass SELECTION = eINSTANCE.getSelection();
 
         /**
-         * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute SELECTION__ID = eINSTANCE.getSelection_Id();
 
         /**
-         * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute SELECTION__NAME = eINSTANCE.getSelection_Name();
 
         /**
-         * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute SELECTION__DESCRIPTION = eINSTANCE.getSelection_Description();
 
         /**
-         * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute SELECTION__COMMENT = eINSTANCE.getSelection_Comment();
 
         /**
-         * The meta object literal for the '<em><b>Parent</b></em>' container reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Parent</b></em>' container reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference SELECTION__PARENT = eINSTANCE.getSelection_Parent();
 
         /**
-         * The meta object literal for the '<em><b>Root</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Root</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute SELECTION__ROOT = eINSTANCE.getSelection_Root();
 
         /**
-         * The meta object literal for the '<em><b>Present</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Present</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute SELECTION__PRESENT = eINSTANCE.getSelection_Present();
 
         /**
-         * The meta object literal for the '<em><b>Enabled</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Enabled</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute SELECTION__ENABLED = eINSTANCE.getSelection_Enabled();
 
         /**
-         * The meta object literal for the '<em><b>Selections</b></em>' containment reference list feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Selections</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference SELECTION__SELECTIONS = eINSTANCE.getSelection_Selections();
 
         /**
-         * The meta object literal for the '<em><b>Values</b></em>' containment reference list feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Values</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference SELECTION__VALUES = eINSTANCE.getSelection_Values();
 
         /**
-         * The meta object literal for the '<em><b>Feature Configuration</b></em>' reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Feature Configuration</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference SELECTION__FEATURE_CONFIGURATION = eINSTANCE.getSelection_FeatureConfiguration();
 
         /**
-         * The meta object literal for the '<em><b>Feature</b></em>' reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Feature</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference SELECTION__FEATURE = eINSTANCE.getSelection_Feature();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.AttributeValueImpl <em>Attribute Value</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.AttributeValueImpl <em>Attribute Value</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fc.impl.AttributeValueImpl
-         * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getAttributeValue()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fc.impl.AttributeValueImpl
+		 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getAttributeValue()
+		 * @generated
+		 */
         EClass ATTRIBUTE_VALUE = eINSTANCE.getAttributeValue();
 
         /**
-         * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute ATTRIBUTE_VALUE__ID = eINSTANCE.getAttributeValue_Id();
 
         /**
-         * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute ATTRIBUTE_VALUE__NAME = eINSTANCE.getAttributeValue_Name();
 
         /**
-         * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute ATTRIBUTE_VALUE__DESCRIPTION = eINSTANCE.getAttributeValue_Description();
 
         /**
-         * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute ATTRIBUTE_VALUE__COMMENT = eINSTANCE.getAttributeValue_Comment();
 
         /**
-         * The meta object literal for the '<em><b>Selection</b></em>' container reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Selection</b></em>' container reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference ATTRIBUTE_VALUE__SELECTION = eINSTANCE.getAttributeValue_Selection();
 
         /**
-         * The meta object literal for the '<em><b>Attribute</b></em>' reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Attribute</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference ATTRIBUTE_VALUE__ATTRIBUTE = eINSTANCE.getAttributeValue_Attribute();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.BooleanValueImpl <em>Boolean Value</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.BooleanValueImpl <em>Boolean Value</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fc.impl.BooleanValueImpl
-         * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getBooleanValue()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fc.impl.BooleanValueImpl
+		 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getBooleanValue()
+		 * @generated
+		 */
         EClass BOOLEAN_VALUE = eINSTANCE.getBooleanValue();
 
         /**
-         * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute BOOLEAN_VALUE__VALUE = eINSTANCE.getBooleanValue_Value();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.IntegerValueImpl <em>Integer Value</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.IntegerValueImpl <em>Integer Value</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fc.impl.IntegerValueImpl
-         * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getIntegerValue()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fc.impl.IntegerValueImpl
+		 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getIntegerValue()
+		 * @generated
+		 */
         EClass INTEGER_VALUE = eINSTANCE.getIntegerValue();
 
         /**
-         * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute INTEGER_VALUE__VALUE = eINSTANCE.getIntegerValue_Value();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.DoubleValueImpl <em>Double Value</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.DoubleValueImpl <em>Double Value</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fc.impl.DoubleValueImpl
-         * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getDoubleValue()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fc.impl.DoubleValueImpl
+		 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getDoubleValue()
+		 * @generated
+		 */
         EClass DOUBLE_VALUE = eINSTANCE.getDoubleValue();
 
         /**
-         * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute DOUBLE_VALUE__VALUE = eINSTANCE.getDoubleValue_Value();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.StringValueImpl <em>String Value</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fc.impl.StringValueImpl <em>String Value</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fc.impl.StringValueImpl
-         * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getStringValue()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fc.impl.StringValueImpl
+		 * @see cz.zcu.yafmt.model.fc.impl.FeatureConfigurationPackageImpl#getStringValue()
+		 * @generated
+		 */
         EClass STRING_VALUE = eINSTANCE.getStringValue();
 
         /**
-         * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute STRING_VALUE__VALUE = eINSTANCE.getStringValue_Value();
 
     }

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/IntegerValue.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/IntegerValue.java
@@ -10,10 +10,10 @@ package cz.zcu.yafmt.model.fc;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.IntegerValue#getValue <em>Value</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getIntegerValue()
  * @model
@@ -21,30 +21,30 @@ package cz.zcu.yafmt.model.fc;
  */
 public interface IntegerValue extends AttributeValue {
     /**
-     * Returns the value of the '<em><b>Value</b></em>' attribute.
-     * The default value is <code>"0"</code>.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Value</b></em>' attribute.
+	 * The default value is <code>"0"</code>.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Value</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Value</em>' attribute.
-     * @see #setValue(int)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getIntegerValue_Value()
-     * @model default="0" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Value</em>' attribute.
+	 * @see #setValue(int)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getIntegerValue_Value()
+	 * @model default="0" required="true"
+	 * @generated
+	 */
     int getValue();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.IntegerValue#getValue <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.IntegerValue#getValue <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Value</em>' attribute.
-     * @see #getValue()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Value</em>' attribute.
+	 * @see #getValue()
+	 * @generated
+	 */
     void setValue(int value);
 
 } // IntegerValue

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/Selection.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/Selection.java
@@ -15,6 +15,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.Selection#getId <em>Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.Selection#getName <em>Name</em>}</li>
@@ -29,7 +30,6 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link cz.zcu.yafmt.model.fc.Selection#getFeatureConfiguration <em>Feature Configuration</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.Selection#getFeature <em>Feature</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection()
  * @model
@@ -37,236 +37,236 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface Selection extends EObject {
     /**
-     * Returns the value of the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Id</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Id</em>' attribute.
-     * @see #setId(String)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Id()
-     * @model required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Id</em>' attribute.
+	 * @see #setId(String)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Id()
+	 * @model required="true"
+	 * @generated
+	 */
     String getId();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.Selection#getId <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.Selection#getId <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Id</em>' attribute.
-     * @see #getId()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Id</em>' attribute.
+	 * @see #getId()
+	 * @generated
+	 */
     void setId(String value);
 
     /**
-     * Returns the value of the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Name</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Name</em>' attribute.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Name()
-     * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Name</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Name()
+	 * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     String getName();
 
     /**
-     * Returns the value of the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Description</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Description</em>' attribute.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Description()
-     * @model transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Description</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Description()
+	 * @model transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     String getDescription();
 
     /**
-     * Returns the value of the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Comment</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Comment</em>' attribute.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Comment()
-     * @model transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Comment</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Comment()
+	 * @model transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     String getComment();
 
     /**
-     * Returns the value of the '<em><b>Parent</b></em>' container reference.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fc.Selection#getSelections <em>Selections</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Parent</b></em>' container reference.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fc.Selection#getSelections <em>Selections</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Parent</em>' container reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Parent</em>' container reference.
-     * @see #setParent(Selection)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Parent()
-     * @see cz.zcu.yafmt.model.fc.Selection#getSelections
-     * @model opposite="selections" transient="false"
-     * @generated
-     */
+	 * @return the value of the '<em>Parent</em>' container reference.
+	 * @see #setParent(Selection)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Parent()
+	 * @see cz.zcu.yafmt.model.fc.Selection#getSelections
+	 * @model opposite="selections" transient="false"
+	 * @generated
+	 */
     Selection getParent();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.Selection#getParent <em>Parent</em>}' container reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.Selection#getParent <em>Parent</em>}' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Parent</em>' container reference.
-     * @see #getParent()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Parent</em>' container reference.
+	 * @see #getParent()
+	 * @generated
+	 */
     void setParent(Selection value);
 
     /**
-     * Returns the value of the '<em><b>Root</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Root</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Root</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Root</em>' attribute.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Root()
-     * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Root</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Root()
+	 * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     boolean isRoot();
 
     /**
-     * Returns the value of the '<em><b>Present</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Present</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Present</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Present</em>' attribute.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Present()
-     * @model transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Present</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Present()
+	 * @model transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     boolean isPresent();
 
     /**
-     * Returns the value of the '<em><b>Enabled</b></em>' attribute.
-     * The default value is <code>"true"</code>.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Enabled</b></em>' attribute.
+	 * The default value is <code>"true"</code>.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Enabled</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Enabled</em>' attribute.
-     * @see #setEnabled(boolean)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Enabled()
-     * @model default="true" required="true" transient="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Enabled</em>' attribute.
+	 * @see #setEnabled(boolean)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Enabled()
+	 * @model default="true" required="true" transient="true"
+	 * @generated
+	 */
     boolean isEnabled();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.Selection#isEnabled <em>Enabled</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.Selection#isEnabled <em>Enabled</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Enabled</em>' attribute.
-     * @see #isEnabled()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Enabled</em>' attribute.
+	 * @see #isEnabled()
+	 * @generated
+	 */
     void setEnabled(boolean value);
 
     /**
-     * Returns the value of the '<em><b>Selections</b></em>' containment reference list.
-     * The list contents are of type {@link cz.zcu.yafmt.model.fc.Selection}.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fc.Selection#getParent <em>Parent</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Selections</b></em>' containment reference list.
+	 * The list contents are of type {@link cz.zcu.yafmt.model.fc.Selection}.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fc.Selection#getParent <em>Parent</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Selections</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Selections</em>' containment reference list.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Selections()
-     * @see cz.zcu.yafmt.model.fc.Selection#getParent
-     * @model opposite="parent" containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Selections</em>' containment reference list.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Selections()
+	 * @see cz.zcu.yafmt.model.fc.Selection#getParent
+	 * @model opposite="parent" containment="true"
+	 * @generated
+	 */
     EList<Selection> getSelections();
 
     /**
-     * Returns the value of the '<em><b>Values</b></em>' containment reference list.
-     * The list contents are of type {@link cz.zcu.yafmt.model.fc.AttributeValue}.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fc.AttributeValue#getSelection <em>Selection</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Values</b></em>' containment reference list.
+	 * The list contents are of type {@link cz.zcu.yafmt.model.fc.AttributeValue}.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fc.AttributeValue#getSelection <em>Selection</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Values</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Values</em>' containment reference list.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Values()
-     * @see cz.zcu.yafmt.model.fc.AttributeValue#getSelection
-     * @model opposite="selection" containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Values</em>' containment reference list.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Values()
+	 * @see cz.zcu.yafmt.model.fc.AttributeValue#getSelection
+	 * @model opposite="selection" containment="true"
+	 * @generated
+	 */
     EList<AttributeValue> getValues();
 
     /**
-     * Returns the value of the '<em><b>Feature Configuration</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Feature Configuration</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Feature Configuration</em>' reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Feature Configuration</em>' reference.
-     * @see #setFeatureConfiguration(FeatureConfiguration)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_FeatureConfiguration()
-     * @model required="true" transient="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Feature Configuration</em>' reference.
+	 * @see #setFeatureConfiguration(FeatureConfiguration)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_FeatureConfiguration()
+	 * @model required="true" transient="true" derived="true"
+	 * @generated
+	 */
     FeatureConfiguration getFeatureConfiguration();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.Selection#getFeatureConfiguration <em>Feature Configuration</em>}' reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.Selection#getFeatureConfiguration <em>Feature Configuration</em>}' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Feature Configuration</em>' reference.
-     * @see #getFeatureConfiguration()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Feature Configuration</em>' reference.
+	 * @see #getFeatureConfiguration()
+	 * @generated
+	 */
     void setFeatureConfiguration(FeatureConfiguration value);
 
     /**
-     * Returns the value of the '<em><b>Feature</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Feature</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Feature</em>' reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Feature</em>' reference.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Feature()
-     * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Feature</em>' reference.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getSelection_Feature()
+	 * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     Feature getFeature();
 
 } // Selection

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/StringValue.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/StringValue.java
@@ -10,10 +10,10 @@ package cz.zcu.yafmt.model.fc;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.StringValue#getValue <em>Value</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getStringValue()
  * @model
@@ -21,30 +21,30 @@ package cz.zcu.yafmt.model.fc;
  */
 public interface StringValue extends AttributeValue {
     /**
-     * Returns the value of the '<em><b>Value</b></em>' attribute.
-     * The default value is <code>""</code>.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Value</b></em>' attribute.
+	 * The default value is <code>""</code>.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Value</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Value</em>' attribute.
-     * @see #setValue(String)
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getStringValue_Value()
-     * @model default="" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Value</em>' attribute.
+	 * @see #setValue(String)
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#getStringValue_Value()
+	 * @model default="" required="true"
+	 * @generated
+	 */
     String getValue();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fc.StringValue#getValue <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fc.StringValue#getValue <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Value</em>' attribute.
-     * @see #getValue()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Value</em>' attribute.
+	 * @see #getValue()
+	 * @generated
+	 */
     void setValue(String value);
 
 } // StringValue

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/AttributeValueImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/AttributeValueImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.AttributeValueImpl#getId <em>Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.AttributeValueImpl#getName <em>Name</em>}</li>
@@ -34,100 +35,99 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.AttributeValueImpl#getSelection <em>Selection</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.AttributeValueImpl#getAttribute <em>Attribute</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public abstract class AttributeValueImpl extends EObjectImpl implements AttributeValue {
     /**
-     * The default value of the '{@link #getId() <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String ID_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
     protected String id = ID_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String NAME_EDEFAULT = null;
 
     /**
-     * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String DESCRIPTION_EDEFAULT = null;
 
     /**
-     * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String COMMENT_EDEFAULT = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected AttributeValueImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE;
-    }
+		return FeatureConfigurationPackage.Literals.ATTRIBUTE_VALUE;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getId() {
-        return id;
-    }
+		return id;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setId(String newId) {
-        String oldId = id;
-        id = newId;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID, oldId, id));
-    }
+		String oldId = id;
+		id = newId;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID, oldId, id));
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -160,55 +160,55 @@ public abstract class AttributeValueImpl extends EObjectImpl implements Attribut
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Selection getSelection() {
-        if (eContainerFeatureID() != FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION) return null;
-        return (Selection)eContainer();
-    }
+		if (eContainerFeatureID() != FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION) return null;
+		return (Selection)eInternalContainer();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetSelection(Selection newSelection, NotificationChain msgs) {
-        msgs = eBasicSetContainer((InternalEObject)newSelection, FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION, msgs);
-        return msgs;
-    }
+		msgs = eBasicSetContainer((InternalEObject)newSelection, FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION, msgs);
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setSelection(Selection newSelection) {
-        if (newSelection != eInternalContainer() || (eContainerFeatureID() != FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION && newSelection != null)) {
-            if (EcoreUtil.isAncestor(this, newSelection))
-                throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
-            NotificationChain msgs = null;
-            if (eInternalContainer() != null)
-                msgs = eBasicRemoveFromContainer(msgs);
-            if (newSelection != null)
-                msgs = ((InternalEObject)newSelection).eInverseAdd(this, FeatureConfigurationPackage.SELECTION__VALUES, Selection.class, msgs);
-            msgs = basicSetSelection(newSelection, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION, newSelection, newSelection));
-    }
+		if (newSelection != eInternalContainer() || (eContainerFeatureID() != FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION && newSelection != null)) {
+			if (EcoreUtil.isAncestor(this, newSelection))
+				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
+			NotificationChain msgs = null;
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
+			if (newSelection != null)
+				msgs = ((InternalEObject)newSelection).eInverseAdd(this, FeatureConfigurationPackage.SELECTION__VALUES, Selection.class, msgs);
+			msgs = basicSetSelection(newSelection, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION, newSelection, newSelection));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Attribute getAttribute() {
-        Attribute attribute = basicGetAttribute();
-        return attribute != null && attribute.eIsProxy() ? (Attribute)eResolveProxy((InternalEObject)attribute) : attribute;
-    }
+		Attribute attribute = basicGetAttribute();
+		return attribute != null && attribute.eIsProxy() ? (Attribute)eResolveProxy((InternalEObject)attribute) : attribute;
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -232,148 +232,148 @@ public abstract class AttributeValueImpl extends EObjectImpl implements Attribut
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
-                if (eInternalContainer() != null)
-                    msgs = eBasicRemoveFromContainer(msgs);
-                return basicSetSelection((Selection)otherEnd, msgs);
-        }
-        return super.eInverseAdd(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
+				if (eInternalContainer() != null)
+					msgs = eBasicRemoveFromContainer(msgs);
+				return basicSetSelection((Selection)otherEnd, msgs);
+		}
+		return super.eInverseAdd(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
-                return basicSetSelection(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
+				return basicSetSelection(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eBasicRemoveFromContainerFeature(NotificationChain msgs) {
-        switch (eContainerFeatureID()) {
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
-                return eInternalContainer().eInverseRemove(this, FeatureConfigurationPackage.SELECTION__VALUES, Selection.class, msgs);
-        }
-        return super.eBasicRemoveFromContainerFeature(msgs);
-    }
+		switch (eContainerFeatureID()) {
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
+				return eInternalContainer().eInverseRemove(this, FeatureConfigurationPackage.SELECTION__VALUES, Selection.class, msgs);
+		}
+		return super.eBasicRemoveFromContainerFeature(msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
-                return getId();
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__NAME:
-                return getName();
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__DESCRIPTION:
-                return getDescription();
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__COMMENT:
-                return getComment();
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
-                return getSelection();
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ATTRIBUTE:
-                if (resolve) return getAttribute();
-                return basicGetAttribute();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
+				return getId();
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__NAME:
+				return getName();
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__DESCRIPTION:
+				return getDescription();
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__COMMENT:
+				return getComment();
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
+				return getSelection();
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ATTRIBUTE:
+				if (resolve) return getAttribute();
+				return basicGetAttribute();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
-                setId((String)newValue);
-                return;
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
-                setSelection((Selection)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
+				setId((String)newValue);
+				return;
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
+				setSelection((Selection)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
-                setId(ID_EDEFAULT);
-                return;
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
-                setSelection((Selection)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
+				setId(ID_EDEFAULT);
+				return;
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
+				setSelection((Selection)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
-                return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__NAME:
-                return NAME_EDEFAULT == null ? getName() != null : !NAME_EDEFAULT.equals(getName());
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__DESCRIPTION:
-                return DESCRIPTION_EDEFAULT == null ? getDescription() != null : !DESCRIPTION_EDEFAULT.equals(getDescription());
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__COMMENT:
-                return COMMENT_EDEFAULT == null ? getComment() != null : !COMMENT_EDEFAULT.equals(getComment());
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
-                return getSelection() != null;
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ATTRIBUTE:
-                return basicGetAttribute() != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ID:
+				return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__NAME:
+				return NAME_EDEFAULT == null ? getName() != null : !NAME_EDEFAULT.equals(getName());
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__DESCRIPTION:
+				return DESCRIPTION_EDEFAULT == null ? getDescription() != null : !DESCRIPTION_EDEFAULT.equals(getDescription());
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__COMMENT:
+				return COMMENT_EDEFAULT == null ? getComment() != null : !COMMENT_EDEFAULT.equals(getComment());
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION:
+				return getSelection() != null;
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE__ATTRIBUTE:
+				return basicGetAttribute() != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (id: ");
-        result.append(id);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (id: ");
+		result.append(id);
+		result.append(')');
+		return result.toString();
+	}
 
 } //AttributeValueImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/BooleanValueImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/BooleanValueImpl.java
@@ -15,146 +15,146 @@ import cz.zcu.yafmt.model.fc.FeatureConfigurationPackage;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.BooleanValueImpl#isValue <em>Value</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class BooleanValueImpl extends AttributeValueImpl implements BooleanValue {
     /**
-     * The default value of the '{@link #isValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #isValue()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean VALUE_EDEFAULT = false;
 
     /**
-     * The cached value of the '{@link #isValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #isValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #isValue()
+	 * @generated
+	 * @ordered
+	 */
     protected boolean value = VALUE_EDEFAULT;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected BooleanValueImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureConfigurationPackage.Literals.BOOLEAN_VALUE;
-    }
+		return FeatureConfigurationPackage.Literals.BOOLEAN_VALUE;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public boolean isValue() {
-        return value;
-    }
+		return value;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setValue(boolean newValue) {
-        boolean oldValue = value;
-        value = newValue;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE, oldValue, value));
-    }
+		boolean oldValue = value;
+		value = newValue;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE, oldValue, value));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
-                return isValue();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
+				return isValue();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
-                setValue((Boolean)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
+				setValue((Boolean)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
-                setValue(VALUE_EDEFAULT);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
+				setValue(VALUE_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
-                return value != VALUE_EDEFAULT;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.BOOLEAN_VALUE__VALUE:
+				return value != VALUE_EDEFAULT;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (value: ");
-        result.append(value);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (value: ");
+		result.append(value);
+		result.append(')');
+		return result.toString();
+	}
 
 } //BooleanValueImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/DoubleValueImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/DoubleValueImpl.java
@@ -15,146 +15,146 @@ import cz.zcu.yafmt.model.fc.FeatureConfigurationPackage;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.DoubleValueImpl#getValue <em>Value</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class DoubleValueImpl extends AttributeValueImpl implements DoubleValue {
     /**
-     * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
     protected static final double VALUE_EDEFAULT = 0.0;
 
     /**
-     * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
     protected double value = VALUE_EDEFAULT;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected DoubleValueImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureConfigurationPackage.Literals.DOUBLE_VALUE;
-    }
+		return FeatureConfigurationPackage.Literals.DOUBLE_VALUE;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public double getValue() {
-        return value;
-    }
+		return value;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setValue(double newValue) {
-        double oldValue = value;
-        value = newValue;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.DOUBLE_VALUE__VALUE, oldValue, value));
-    }
+		double oldValue = value;
+		value = newValue;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.DOUBLE_VALUE__VALUE, oldValue, value));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
-                return getValue();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
+				return getValue();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
-                setValue((Double)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
+				setValue((Double)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
-                setValue(VALUE_EDEFAULT);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
+				setValue(VALUE_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
-                return value != VALUE_EDEFAULT;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.DOUBLE_VALUE__VALUE:
+				return value != VALUE_EDEFAULT;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (value: ");
-        result.append(value);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (value: ");
+		result.append(value);
+		result.append(')');
+		return result.toString();
+	}
 
 } //DoubleValueImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/FeatureConfigurationFactoryImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/FeatureConfigurationFactoryImpl.java
@@ -20,131 +20,131 @@ import org.eclipse.emf.ecore.plugin.EcorePlugin;
  */
 public class FeatureConfigurationFactoryImpl extends EFactoryImpl implements FeatureConfigurationFactory {
     /**
-     * Creates the default factory implementation.
-     * <!-- begin-user-doc -->
+	 * Creates the default factory implementation.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public static FeatureConfigurationFactory init() {
-        try {
-            FeatureConfigurationFactory theFeatureConfigurationFactory = (FeatureConfigurationFactory)EPackage.Registry.INSTANCE.getEFactory("http://zcu.cz/yafmt/model/fc"); 
-            if (theFeatureConfigurationFactory != null) {
-                return theFeatureConfigurationFactory;
-            }
-        }
-        catch (Exception exception) {
-            EcorePlugin.INSTANCE.log(exception);
-        }
-        return new FeatureConfigurationFactoryImpl();
-    }
+		try {
+			FeatureConfigurationFactory theFeatureConfigurationFactory = (FeatureConfigurationFactory)EPackage.Registry.INSTANCE.getEFactory(FeatureConfigurationPackage.eNS_URI);
+			if (theFeatureConfigurationFactory != null) {
+				return theFeatureConfigurationFactory;
+			}
+		}
+		catch (Exception exception) {
+			EcorePlugin.INSTANCE.log(exception);
+		}
+		return new FeatureConfigurationFactoryImpl();
+	}
 
     /**
-     * Creates an instance of the factory.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureConfigurationFactoryImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public EObject create(EClass eClass) {
-        switch (eClass.getClassifierID()) {
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION: return createFeatureConfiguration();
-            case FeatureConfigurationPackage.SELECTION: return createSelection();
-            case FeatureConfigurationPackage.BOOLEAN_VALUE: return createBooleanValue();
-            case FeatureConfigurationPackage.INTEGER_VALUE: return createIntegerValue();
-            case FeatureConfigurationPackage.DOUBLE_VALUE: return createDoubleValue();
-            case FeatureConfigurationPackage.STRING_VALUE: return createStringValue();
-            default:
-                throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
-        }
-    }
+		switch (eClass.getClassifierID()) {
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION: return createFeatureConfiguration();
+			case FeatureConfigurationPackage.SELECTION: return createSelection();
+			case FeatureConfigurationPackage.BOOLEAN_VALUE: return createBooleanValue();
+			case FeatureConfigurationPackage.INTEGER_VALUE: return createIntegerValue();
+			case FeatureConfigurationPackage.DOUBLE_VALUE: return createDoubleValue();
+			case FeatureConfigurationPackage.STRING_VALUE: return createStringValue();
+			default:
+				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
+		}
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureConfiguration createFeatureConfiguration() {
-        FeatureConfigurationImpl featureConfiguration = new FeatureConfigurationImpl();
-        return featureConfiguration;
-    }
+		FeatureConfigurationImpl featureConfiguration = new FeatureConfigurationImpl();
+		return featureConfiguration;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Selection createSelection() {
-        SelectionImpl selection = new SelectionImpl();
-        return selection;
-    }
+		SelectionImpl selection = new SelectionImpl();
+		return selection;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public BooleanValue createBooleanValue() {
-        BooleanValueImpl booleanValue = new BooleanValueImpl();
-        return booleanValue;
-    }
+		BooleanValueImpl booleanValue = new BooleanValueImpl();
+		return booleanValue;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public IntegerValue createIntegerValue() {
-        IntegerValueImpl integerValue = new IntegerValueImpl();
-        return integerValue;
-    }
+		IntegerValueImpl integerValue = new IntegerValueImpl();
+		return integerValue;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public DoubleValue createDoubleValue() {
-        DoubleValueImpl doubleValue = new DoubleValueImpl();
-        return doubleValue;
-    }
+		DoubleValueImpl doubleValue = new DoubleValueImpl();
+		return doubleValue;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public StringValue createStringValue() {
-        StringValueImpl stringValue = new StringValueImpl();
-        return stringValue;
-    }
+		StringValueImpl stringValue = new StringValueImpl();
+		return stringValue;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureConfigurationPackage getFeatureConfigurationPackage() {
-        return (FeatureConfigurationPackage)getEPackage();
-    }
+		return (FeatureConfigurationPackage)getEPackage();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @deprecated
-     * @generated
-     */
+	 * @deprecated
+	 * @generated
+	 */
     @Deprecated
     public static FeatureConfigurationPackage getPackage() {
-        return FeatureConfigurationPackage.eINSTANCE;
-    }
+		return FeatureConfigurationPackage.eINSTANCE;
+	}
 
 } //FeatureConfigurationFactoryImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/FeatureConfigurationImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/FeatureConfigurationImpl.java
@@ -22,6 +22,7 @@ import cz.zcu.yafmt.model.fm.FeatureModel;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl#getName <em>Name</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl#getVersion <em>Version</em>}</li>
@@ -31,349 +32,348 @@ import cz.zcu.yafmt.model.fm.FeatureModel;
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl#getFeatureModelCopy <em>Feature Model Copy</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.FeatureConfigurationImpl#getRoot <em>Root</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class FeatureConfigurationImpl extends EObjectImpl implements FeatureConfiguration {
     /**
-     * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String NAME_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected String name = NAME_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getVersion() <em>Version</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getVersion() <em>Version</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getVersion()
-     * @generated
-     * @ordered
-     */
+	 * @see #getVersion()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String VERSION_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getVersion()
-     * @generated
-     * @ordered
-     */
+	 * @see #getVersion()
+	 * @generated
+	 * @ordered
+	 */
     protected String version = VERSION_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String DESCRIPTION_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected String description = DESCRIPTION_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String COMMENT_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected String comment = COMMENT_EDEFAULT;
 
     /**
-     * The cached value of the '{@link #getFeatureModel() <em>Feature Model</em>}' reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getFeatureModel() <em>Feature Model</em>}' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getFeatureModel()
-     * @generated
-     * @ordered
-     */
+	 * @see #getFeatureModel()
+	 * @generated
+	 * @ordered
+	 */
     protected FeatureModel featureModel;
 
     /**
-     * The cached value of the '{@link #getFeatureModelCopy() <em>Feature Model Copy</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getFeatureModelCopy() <em>Feature Model Copy</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getFeatureModelCopy()
-     * @generated
-     * @ordered
-     */
+	 * @see #getFeatureModelCopy()
+	 * @generated
+	 * @ordered
+	 */
     protected FeatureModel featureModelCopy;
 
     /**
-     * The cached value of the '{@link #getRoot() <em>Root</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getRoot() <em>Root</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getRoot()
-     * @generated
-     * @ordered
-     */
+	 * @see #getRoot()
+	 * @generated
+	 * @ordered
+	 */
     protected Selection root;
     
     private SelectionCache selectionCache;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected FeatureConfigurationImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION;
-    }
+		return FeatureConfigurationPackage.Literals.FEATURE_CONFIGURATION;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getName() {
-        return name;
-    }
+		return name;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setName(String newName) {
-        String oldName = name;
-        name = newName;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME, oldName, name));
-    }
+		String oldName = name;
+		name = newName;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME, oldName, name));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getDescription() {
-        return description;
-    }
+		return description;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setDescription(String newDescription) {
-        String oldDescription = description;
-        description = newDescription;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION, oldDescription, description));
-    }
+		String oldDescription = description;
+		description = newDescription;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION, oldDescription, description));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getComment() {
-        return comment;
-    }
+		return comment;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setComment(String newComment) {
-        String oldComment = comment;
-        comment = newComment;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT, oldComment, comment));
-    }
+		String oldComment = comment;
+		comment = newComment;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT, oldComment, comment));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getVersion() {
-        return version;
-    }
+		return version;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setVersion(String newVersion) {
-        String oldVersion = version;
-        version = newVersion;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION, oldVersion, version));
-    }
+		String oldVersion = version;
+		version = newVersion;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION, oldVersion, version));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModel getFeatureModel() {
-        if (featureModel != null && featureModel.eIsProxy()) {
-            InternalEObject oldFeatureModel = (InternalEObject)featureModel;
-            featureModel = (FeatureModel)eResolveProxy(oldFeatureModel);
-            if (featureModel != oldFeatureModel) {
-                if (eNotificationRequired())
-                    eNotify(new ENotificationImpl(this, Notification.RESOLVE, FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL, oldFeatureModel, featureModel));
-            }
-        }
-        return featureModel;
-    }
+		if (featureModel != null && featureModel.eIsProxy()) {
+			InternalEObject oldFeatureModel = (InternalEObject)featureModel;
+			featureModel = (FeatureModel)eResolveProxy(oldFeatureModel);
+			if (featureModel != oldFeatureModel) {
+				if (eNotificationRequired())
+					eNotify(new ENotificationImpl(this, Notification.RESOLVE, FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL, oldFeatureModel, featureModel));
+			}
+		}
+		return featureModel;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModel basicGetFeatureModel() {
-        return featureModel;
-    }
+		return featureModel;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setFeatureModel(FeatureModel newFeatureModel) {
-        FeatureModel oldFeatureModel = featureModel;
-        featureModel = newFeatureModel;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL, oldFeatureModel, featureModel));
-    }
+		FeatureModel oldFeatureModel = featureModel;
+		featureModel = newFeatureModel;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL, oldFeatureModel, featureModel));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModel getFeatureModelCopy() {
-        return featureModelCopy;
-    }
+		return featureModelCopy;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetFeatureModelCopy(FeatureModel newFeatureModelCopy, NotificationChain msgs) {
-        FeatureModel oldFeatureModelCopy = featureModelCopy;
-        featureModelCopy = newFeatureModelCopy;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY, oldFeatureModelCopy, newFeatureModelCopy);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		FeatureModel oldFeatureModelCopy = featureModelCopy;
+		featureModelCopy = newFeatureModelCopy;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY, oldFeatureModelCopy, newFeatureModelCopy);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setFeatureModelCopy(FeatureModel newFeatureModelCopy) {
-        if (newFeatureModelCopy != featureModelCopy) {
-            NotificationChain msgs = null;
-            if (featureModelCopy != null)
-                msgs = ((InternalEObject)featureModelCopy).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY, null, msgs);
-            if (newFeatureModelCopy != null)
-                msgs = ((InternalEObject)newFeatureModelCopy).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY, null, msgs);
-            msgs = basicSetFeatureModelCopy(newFeatureModelCopy, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY, newFeatureModelCopy, newFeatureModelCopy));
-    }
+		if (newFeatureModelCopy != featureModelCopy) {
+			NotificationChain msgs = null;
+			if (featureModelCopy != null)
+				msgs = ((InternalEObject)featureModelCopy).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY, null, msgs);
+			if (newFeatureModelCopy != null)
+				msgs = ((InternalEObject)newFeatureModelCopy).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY, null, msgs);
+			msgs = basicSetFeatureModelCopy(newFeatureModelCopy, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY, newFeatureModelCopy, newFeatureModelCopy));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Selection getRoot() {
-        return root;
-    }
+		return root;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetRoot(Selection newRoot, NotificationChain msgs) {
-        Selection oldRoot = root;
-        root = newRoot;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT, oldRoot, newRoot);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Selection oldRoot = root;
+		root = newRoot;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT, oldRoot, newRoot);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setRoot(Selection newRoot) {
-        if (newRoot != root) {
-            NotificationChain msgs = null;
-            if (root != null)
-                msgs = ((InternalEObject)root).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT, null, msgs);
-            if (newRoot != null)
-                msgs = ((InternalEObject)newRoot).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT, null, msgs);
-            msgs = basicSetRoot(newRoot, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT, newRoot, newRoot));
-    }
+		if (newRoot != root) {
+			NotificationChain msgs = null;
+			if (root != null)
+				msgs = ((InternalEObject)root).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT, null, msgs);
+			if (newRoot != null)
+				msgs = ((InternalEObject)newRoot).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT, null, msgs);
+			msgs = basicSetRoot(newRoot, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT, newRoot, newRoot));
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -387,160 +387,160 @@ public class FeatureConfigurationImpl extends EObjectImpl implements FeatureConf
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
-                return basicSetFeatureModelCopy(null, msgs);
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
-                return basicSetRoot(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
+				return basicSetFeatureModelCopy(null, msgs);
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
+				return basicSetRoot(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
-                return getName();
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
-                return getVersion();
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
-                return getDescription();
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
-                return getComment();
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL:
-                if (resolve) return getFeatureModel();
-                return basicGetFeatureModel();
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
-                return getFeatureModelCopy();
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
-                return getRoot();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
+				return getName();
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
+				return getVersion();
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
+				return getDescription();
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
+				return getComment();
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL:
+				if (resolve) return getFeatureModel();
+				return basicGetFeatureModel();
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
+				return getFeatureModelCopy();
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
+				return getRoot();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
-                setName((String)newValue);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
-                setVersion((String)newValue);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
-                setDescription((String)newValue);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
-                setComment((String)newValue);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL:
-                setFeatureModel((FeatureModel)newValue);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
-                setFeatureModelCopy((FeatureModel)newValue);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
-                setRoot((Selection)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
+				setName((String)newValue);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
+				setVersion((String)newValue);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
+				setDescription((String)newValue);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
+				setComment((String)newValue);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL:
+				setFeatureModel((FeatureModel)newValue);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
+				setFeatureModelCopy((FeatureModel)newValue);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
+				setRoot((Selection)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
-                setName(NAME_EDEFAULT);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
-                setVersion(VERSION_EDEFAULT);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
-                setDescription(DESCRIPTION_EDEFAULT);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
-                setComment(COMMENT_EDEFAULT);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL:
-                setFeatureModel((FeatureModel)null);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
-                setFeatureModelCopy((FeatureModel)null);
-                return;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
-                setRoot((Selection)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
+				setName(NAME_EDEFAULT);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
+				setVersion(VERSION_EDEFAULT);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
+				setDescription(DESCRIPTION_EDEFAULT);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
+				setComment(COMMENT_EDEFAULT);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL:
+				setFeatureModel((FeatureModel)null);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
+				setFeatureModelCopy((FeatureModel)null);
+				return;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
+				setRoot((Selection)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
-                return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
-                return VERSION_EDEFAULT == null ? version != null : !VERSION_EDEFAULT.equals(version);
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
-                return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
-                return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL:
-                return featureModel != null;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
-                return featureModelCopy != null;
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
-                return root != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__NAME:
+				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__VERSION:
+				return VERSION_EDEFAULT == null ? version != null : !VERSION_EDEFAULT.equals(version);
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__DESCRIPTION:
+				return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__COMMENT:
+				return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL:
+				return featureModel != null;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__FEATURE_MODEL_COPY:
+				return featureModelCopy != null;
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION__ROOT:
+				return root != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (name: ");
-        result.append(name);
-        result.append(", version: ");
-        result.append(version);
-        result.append(", description: ");
-        result.append(description);
-        result.append(", comment: ");
-        result.append(comment);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (name: ");
+		result.append(name);
+		result.append(", version: ");
+		result.append(version);
+		result.append(", description: ");
+		result.append(description);
+		result.append(", comment: ");
+		result.append(comment);
+		result.append(')');
+		return result.toString();
+	}
 
 } //FeatureConfigurationImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/FeatureConfigurationPackageImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/FeatureConfigurationPackageImpl.java
@@ -33,605 +33,605 @@ import org.eclipse.emf.ecore.impl.EPackageImpl;
  */
 public class FeatureConfigurationPackageImpl extends EPackageImpl implements FeatureConfigurationPackage {
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass featureConfigurationEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass selectionEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass attributeValueEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass booleanValueEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass integerValueEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass doubleValueEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass stringValueEClass = null;
 
     /**
-     * Creates an instance of the model <b>Package</b>, registered with
-     * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-     * package URI value.
-     * <p>Note: the correct way to create the package is via the static
-     * factory method {@link #init init()}, which also performs
-     * initialization of the package, or returns the registered package,
-     * if one already exists.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the model <b>Package</b>, registered with
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
+	 * package URI value.
+	 * <p>Note: the correct way to create the package is via the static
+	 * factory method {@link #init init()}, which also performs
+	 * initialization of the package, or returns the registered package,
+	 * if one already exists.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see org.eclipse.emf.ecore.EPackage.Registry
-     * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#eNS_URI
-     * @see #init()
-     * @generated
-     */
+	 * @see org.eclipse.emf.ecore.EPackage.Registry
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfigurationPackage#eNS_URI
+	 * @see #init()
+	 * @generated
+	 */
     private FeatureConfigurationPackageImpl() {
-        super(eNS_URI, FeatureConfigurationFactory.eINSTANCE);
-    }
+		super(eNS_URI, FeatureConfigurationFactory.eINSTANCE);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private static boolean isInited = false;
 
     /**
-     * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-     * 
-     * <p>This method is used to initialize {@link FeatureConfigurationPackage#eINSTANCE} when that field is accessed.
-     * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-     * <!-- begin-user-doc -->
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * 
+	 * <p>This method is used to initialize {@link FeatureConfigurationPackage#eINSTANCE} when that field is accessed.
+	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #eNS_URI
-     * @see #createPackageContents()
-     * @see #initializePackageContents()
-     * @generated
-     */
+	 * @see #eNS_URI
+	 * @see #createPackageContents()
+	 * @see #initializePackageContents()
+	 * @generated
+	 */
     public static FeatureConfigurationPackage init() {
-        if (isInited) return (FeatureConfigurationPackage)EPackage.Registry.INSTANCE.getEPackage(FeatureConfigurationPackage.eNS_URI);
+		if (isInited) return (FeatureConfigurationPackage)EPackage.Registry.INSTANCE.getEPackage(FeatureConfigurationPackage.eNS_URI);
 
-        // Obtain or create and register package
-        FeatureConfigurationPackageImpl theFeatureConfigurationPackage = (FeatureConfigurationPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof FeatureConfigurationPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new FeatureConfigurationPackageImpl());
+		// Obtain or create and register package
+		FeatureConfigurationPackageImpl theFeatureConfigurationPackage = (FeatureConfigurationPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof FeatureConfigurationPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new FeatureConfigurationPackageImpl());
 
-        isInited = true;
+		isInited = true;
 
-        // Obtain or create and register interdependencies
-        FeatureModelPackageImpl theFeatureModelPackage = (FeatureModelPackageImpl)(EPackage.Registry.INSTANCE.getEPackage(FeatureModelPackage.eNS_URI) instanceof FeatureModelPackageImpl ? EPackage.Registry.INSTANCE.getEPackage(FeatureModelPackage.eNS_URI) : FeatureModelPackage.eINSTANCE);
+		// Obtain or create and register interdependencies
+		FeatureModelPackageImpl theFeatureModelPackage = (FeatureModelPackageImpl)(EPackage.Registry.INSTANCE.getEPackage(FeatureModelPackage.eNS_URI) instanceof FeatureModelPackageImpl ? EPackage.Registry.INSTANCE.getEPackage(FeatureModelPackage.eNS_URI) : FeatureModelPackage.eINSTANCE);
 
-        // Create package meta-data objects
-        theFeatureConfigurationPackage.createPackageContents();
-        theFeatureModelPackage.createPackageContents();
+		// Create package meta-data objects
+		theFeatureConfigurationPackage.createPackageContents();
+		theFeatureModelPackage.createPackageContents();
 
-        // Initialize created meta-data
-        theFeatureConfigurationPackage.initializePackageContents();
-        theFeatureModelPackage.initializePackageContents();
+		// Initialize created meta-data
+		theFeatureConfigurationPackage.initializePackageContents();
+		theFeatureModelPackage.initializePackageContents();
 
-        // Mark meta-data to indicate it can't be changed
-        theFeatureConfigurationPackage.freeze();
+		// Mark meta-data to indicate it can't be changed
+		theFeatureConfigurationPackage.freeze();
 
   
-        // Update the registry and return the package
-        EPackage.Registry.INSTANCE.put(FeatureConfigurationPackage.eNS_URI, theFeatureConfigurationPackage);
-        return theFeatureConfigurationPackage;
-    }
+		// Update the registry and return the package
+		EPackage.Registry.INSTANCE.put(FeatureConfigurationPackage.eNS_URI, theFeatureConfigurationPackage);
+		return theFeatureConfigurationPackage;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getFeatureConfiguration() {
-        return featureConfigurationEClass;
-    }
+		return featureConfigurationEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeatureConfiguration_Name() {
-        return (EAttribute)featureConfigurationEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)featureConfigurationEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeatureConfiguration_Description() {
-        return (EAttribute)featureConfigurationEClass.getEStructuralFeatures().get(2);
-    }
+		return (EAttribute)featureConfigurationEClass.getEStructuralFeatures().get(2);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeatureConfiguration_Comment() {
-        return (EAttribute)featureConfigurationEClass.getEStructuralFeatures().get(3);
-    }
+		return (EAttribute)featureConfigurationEClass.getEStructuralFeatures().get(3);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeatureConfiguration_Version() {
-        return (EAttribute)featureConfigurationEClass.getEStructuralFeatures().get(1);
-    }
+		return (EAttribute)featureConfigurationEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeatureConfiguration_FeatureModel() {
-        return (EReference)featureConfigurationEClass.getEStructuralFeatures().get(4);
-    }
+		return (EReference)featureConfigurationEClass.getEStructuralFeatures().get(4);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeatureConfiguration_FeatureModelCopy() {
-        return (EReference)featureConfigurationEClass.getEStructuralFeatures().get(5);
-    }
+		return (EReference)featureConfigurationEClass.getEStructuralFeatures().get(5);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeatureConfiguration_Root() {
-        return (EReference)featureConfigurationEClass.getEStructuralFeatures().get(6);
-    }
+		return (EReference)featureConfigurationEClass.getEStructuralFeatures().get(6);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getSelection() {
-        return selectionEClass;
-    }
+		return selectionEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getSelection_Id() {
-        return (EAttribute)selectionEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)selectionEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getSelection_Name() {
-        return (EAttribute)selectionEClass.getEStructuralFeatures().get(1);
-    }
+		return (EAttribute)selectionEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getSelection_Description() {
-        return (EAttribute)selectionEClass.getEStructuralFeatures().get(2);
-    }
+		return (EAttribute)selectionEClass.getEStructuralFeatures().get(2);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getSelection_Comment() {
-        return (EAttribute)selectionEClass.getEStructuralFeatures().get(3);
-    }
+		return (EAttribute)selectionEClass.getEStructuralFeatures().get(3);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getSelection_Parent() {
-        return (EReference)selectionEClass.getEStructuralFeatures().get(4);
-    }
+		return (EReference)selectionEClass.getEStructuralFeatures().get(4);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getSelection_Root() {
-        return (EAttribute)selectionEClass.getEStructuralFeatures().get(5);
-    }
+		return (EAttribute)selectionEClass.getEStructuralFeatures().get(5);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getSelection_Present() {
-        return (EAttribute)selectionEClass.getEStructuralFeatures().get(6);
-    }
+		return (EAttribute)selectionEClass.getEStructuralFeatures().get(6);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getSelection_Enabled() {
-        return (EAttribute)selectionEClass.getEStructuralFeatures().get(7);
-    }
+		return (EAttribute)selectionEClass.getEStructuralFeatures().get(7);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getSelection_Selections() {
-        return (EReference)selectionEClass.getEStructuralFeatures().get(9);
-    }
+		return (EReference)selectionEClass.getEStructuralFeatures().get(9);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getSelection_Values() {
-        return (EReference)selectionEClass.getEStructuralFeatures().get(8);
-    }
+		return (EReference)selectionEClass.getEStructuralFeatures().get(8);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getSelection_FeatureConfiguration() {
-        return (EReference)selectionEClass.getEStructuralFeatures().get(10);
-    }
+		return (EReference)selectionEClass.getEStructuralFeatures().get(10);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getSelection_Feature() {
-        return (EReference)selectionEClass.getEStructuralFeatures().get(11);
-    }
+		return (EReference)selectionEClass.getEStructuralFeatures().get(11);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getAttributeValue() {
-        return attributeValueEClass;
-    }
+		return attributeValueEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getAttributeValue_Id() {
-        return (EAttribute)attributeValueEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)attributeValueEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getAttributeValue_Name() {
-        return (EAttribute)attributeValueEClass.getEStructuralFeatures().get(1);
-    }
+		return (EAttribute)attributeValueEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getAttributeValue_Description() {
-        return (EAttribute)attributeValueEClass.getEStructuralFeatures().get(2);
-    }
+		return (EAttribute)attributeValueEClass.getEStructuralFeatures().get(2);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getAttributeValue_Comment() {
-        return (EAttribute)attributeValueEClass.getEStructuralFeatures().get(3);
-    }
+		return (EAttribute)attributeValueEClass.getEStructuralFeatures().get(3);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getAttributeValue_Selection() {
-        return (EReference)attributeValueEClass.getEStructuralFeatures().get(4);
-    }
+		return (EReference)attributeValueEClass.getEStructuralFeatures().get(4);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getAttributeValue_Attribute() {
-        return (EReference)attributeValueEClass.getEStructuralFeatures().get(5);
-    }
+		return (EReference)attributeValueEClass.getEStructuralFeatures().get(5);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getBooleanValue() {
-        return booleanValueEClass;
-    }
+		return booleanValueEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getBooleanValue_Value() {
-        return (EAttribute)booleanValueEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)booleanValueEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getIntegerValue() {
-        return integerValueEClass;
-    }
+		return integerValueEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getIntegerValue_Value() {
-        return (EAttribute)integerValueEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)integerValueEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getDoubleValue() {
-        return doubleValueEClass;
-    }
+		return doubleValueEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getDoubleValue_Value() {
-        return (EAttribute)doubleValueEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)doubleValueEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getStringValue() {
-        return stringValueEClass;
-    }
+		return stringValueEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getStringValue_Value() {
-        return (EAttribute)stringValueEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)stringValueEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureConfigurationFactory getFeatureConfigurationFactory() {
-        return (FeatureConfigurationFactory)getEFactoryInstance();
-    }
+		return (FeatureConfigurationFactory)getEFactoryInstance();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private boolean isCreated = false;
 
     /**
-     * Creates the meta-model objects for the package.  This method is
-     * guarded to have no affect on any invocation but its first.
-     * <!-- begin-user-doc -->
+	 * Creates the meta-model objects for the package.  This method is
+	 * guarded to have no affect on any invocation but its first.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void createPackageContents() {
-        if (isCreated) return;
-        isCreated = true;
+		if (isCreated) return;
+		isCreated = true;
 
-        // Create classes and their features
-        featureConfigurationEClass = createEClass(FEATURE_CONFIGURATION);
-        createEAttribute(featureConfigurationEClass, FEATURE_CONFIGURATION__NAME);
-        createEAttribute(featureConfigurationEClass, FEATURE_CONFIGURATION__VERSION);
-        createEAttribute(featureConfigurationEClass, FEATURE_CONFIGURATION__DESCRIPTION);
-        createEAttribute(featureConfigurationEClass, FEATURE_CONFIGURATION__COMMENT);
-        createEReference(featureConfigurationEClass, FEATURE_CONFIGURATION__FEATURE_MODEL);
-        createEReference(featureConfigurationEClass, FEATURE_CONFIGURATION__FEATURE_MODEL_COPY);
-        createEReference(featureConfigurationEClass, FEATURE_CONFIGURATION__ROOT);
+		// Create classes and their features
+		featureConfigurationEClass = createEClass(FEATURE_CONFIGURATION);
+		createEAttribute(featureConfigurationEClass, FEATURE_CONFIGURATION__NAME);
+		createEAttribute(featureConfigurationEClass, FEATURE_CONFIGURATION__VERSION);
+		createEAttribute(featureConfigurationEClass, FEATURE_CONFIGURATION__DESCRIPTION);
+		createEAttribute(featureConfigurationEClass, FEATURE_CONFIGURATION__COMMENT);
+		createEReference(featureConfigurationEClass, FEATURE_CONFIGURATION__FEATURE_MODEL);
+		createEReference(featureConfigurationEClass, FEATURE_CONFIGURATION__FEATURE_MODEL_COPY);
+		createEReference(featureConfigurationEClass, FEATURE_CONFIGURATION__ROOT);
 
-        selectionEClass = createEClass(SELECTION);
-        createEAttribute(selectionEClass, SELECTION__ID);
-        createEAttribute(selectionEClass, SELECTION__NAME);
-        createEAttribute(selectionEClass, SELECTION__DESCRIPTION);
-        createEAttribute(selectionEClass, SELECTION__COMMENT);
-        createEReference(selectionEClass, SELECTION__PARENT);
-        createEAttribute(selectionEClass, SELECTION__ROOT);
-        createEAttribute(selectionEClass, SELECTION__PRESENT);
-        createEAttribute(selectionEClass, SELECTION__ENABLED);
-        createEReference(selectionEClass, SELECTION__VALUES);
-        createEReference(selectionEClass, SELECTION__SELECTIONS);
-        createEReference(selectionEClass, SELECTION__FEATURE_CONFIGURATION);
-        createEReference(selectionEClass, SELECTION__FEATURE);
+		selectionEClass = createEClass(SELECTION);
+		createEAttribute(selectionEClass, SELECTION__ID);
+		createEAttribute(selectionEClass, SELECTION__NAME);
+		createEAttribute(selectionEClass, SELECTION__DESCRIPTION);
+		createEAttribute(selectionEClass, SELECTION__COMMENT);
+		createEReference(selectionEClass, SELECTION__PARENT);
+		createEAttribute(selectionEClass, SELECTION__ROOT);
+		createEAttribute(selectionEClass, SELECTION__PRESENT);
+		createEAttribute(selectionEClass, SELECTION__ENABLED);
+		createEReference(selectionEClass, SELECTION__VALUES);
+		createEReference(selectionEClass, SELECTION__SELECTIONS);
+		createEReference(selectionEClass, SELECTION__FEATURE_CONFIGURATION);
+		createEReference(selectionEClass, SELECTION__FEATURE);
 
-        attributeValueEClass = createEClass(ATTRIBUTE_VALUE);
-        createEAttribute(attributeValueEClass, ATTRIBUTE_VALUE__ID);
-        createEAttribute(attributeValueEClass, ATTRIBUTE_VALUE__NAME);
-        createEAttribute(attributeValueEClass, ATTRIBUTE_VALUE__DESCRIPTION);
-        createEAttribute(attributeValueEClass, ATTRIBUTE_VALUE__COMMENT);
-        createEReference(attributeValueEClass, ATTRIBUTE_VALUE__SELECTION);
-        createEReference(attributeValueEClass, ATTRIBUTE_VALUE__ATTRIBUTE);
+		attributeValueEClass = createEClass(ATTRIBUTE_VALUE);
+		createEAttribute(attributeValueEClass, ATTRIBUTE_VALUE__ID);
+		createEAttribute(attributeValueEClass, ATTRIBUTE_VALUE__NAME);
+		createEAttribute(attributeValueEClass, ATTRIBUTE_VALUE__DESCRIPTION);
+		createEAttribute(attributeValueEClass, ATTRIBUTE_VALUE__COMMENT);
+		createEReference(attributeValueEClass, ATTRIBUTE_VALUE__SELECTION);
+		createEReference(attributeValueEClass, ATTRIBUTE_VALUE__ATTRIBUTE);
 
-        booleanValueEClass = createEClass(BOOLEAN_VALUE);
-        createEAttribute(booleanValueEClass, BOOLEAN_VALUE__VALUE);
+		booleanValueEClass = createEClass(BOOLEAN_VALUE);
+		createEAttribute(booleanValueEClass, BOOLEAN_VALUE__VALUE);
 
-        integerValueEClass = createEClass(INTEGER_VALUE);
-        createEAttribute(integerValueEClass, INTEGER_VALUE__VALUE);
+		integerValueEClass = createEClass(INTEGER_VALUE);
+		createEAttribute(integerValueEClass, INTEGER_VALUE__VALUE);
 
-        doubleValueEClass = createEClass(DOUBLE_VALUE);
-        createEAttribute(doubleValueEClass, DOUBLE_VALUE__VALUE);
+		doubleValueEClass = createEClass(DOUBLE_VALUE);
+		createEAttribute(doubleValueEClass, DOUBLE_VALUE__VALUE);
 
-        stringValueEClass = createEClass(STRING_VALUE);
-        createEAttribute(stringValueEClass, STRING_VALUE__VALUE);
-    }
+		stringValueEClass = createEClass(STRING_VALUE);
+		createEAttribute(stringValueEClass, STRING_VALUE__VALUE);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private boolean isInitialized = false;
 
     /**
-     * Complete the initialization of the package and its meta-model.  This
-     * method is guarded to have no affect on any invocation but its first.
-     * <!-- begin-user-doc -->
+	 * Complete the initialization of the package and its meta-model.  This
+	 * method is guarded to have no affect on any invocation but its first.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void initializePackageContents() {
-        if (isInitialized) return;
-        isInitialized = true;
+		if (isInitialized) return;
+		isInitialized = true;
 
-        // Initialize package
-        setName(eNAME);
-        setNsPrefix(eNS_PREFIX);
-        setNsURI(eNS_URI);
+		// Initialize package
+		setName(eNAME);
+		setNsPrefix(eNS_PREFIX);
+		setNsURI(eNS_URI);
 
-        // Obtain other dependent packages
-        FeatureModelPackage theFeatureModelPackage = (FeatureModelPackage)EPackage.Registry.INSTANCE.getEPackage(FeatureModelPackage.eNS_URI);
+		// Obtain other dependent packages
+		FeatureModelPackage theFeatureModelPackage = (FeatureModelPackage)EPackage.Registry.INSTANCE.getEPackage(FeatureModelPackage.eNS_URI);
 
-        // Create type parameters
+		// Create type parameters
 
-        // Set bounds for type parameters
+		// Set bounds for type parameters
 
-        // Add supertypes to classes
-        booleanValueEClass.getESuperTypes().add(this.getAttributeValue());
-        integerValueEClass.getESuperTypes().add(this.getAttributeValue());
-        doubleValueEClass.getESuperTypes().add(this.getAttributeValue());
-        stringValueEClass.getESuperTypes().add(this.getAttributeValue());
+		// Add supertypes to classes
+		booleanValueEClass.getESuperTypes().add(this.getAttributeValue());
+		integerValueEClass.getESuperTypes().add(this.getAttributeValue());
+		doubleValueEClass.getESuperTypes().add(this.getAttributeValue());
+		stringValueEClass.getESuperTypes().add(this.getAttributeValue());
 
-        // Initialize classes and features; add operations and parameters
-        initEClass(featureConfigurationEClass, FeatureConfiguration.class, "FeatureConfiguration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getFeatureConfiguration_Name(), ecorePackage.getEString(), "name", null, 1, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeatureConfiguration_Version(), ecorePackage.getEString(), "version", null, 0, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeatureConfiguration_Description(), ecorePackage.getEString(), "description", null, 0, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeatureConfiguration_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeatureConfiguration_FeatureModel(), theFeatureModelPackage.getFeatureModel(), null, "featureModel", null, 0, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeatureConfiguration_FeatureModelCopy(), theFeatureModelPackage.getFeatureModel(), null, "featureModelCopy", null, 1, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeatureConfiguration_Root(), this.getSelection(), null, "root", null, 1, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		// Initialize classes and features; add operations and parameters
+		initEClass(featureConfigurationEClass, FeatureConfiguration.class, "FeatureConfiguration", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getFeatureConfiguration_Name(), ecorePackage.getEString(), "name", null, 1, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeatureConfiguration_Version(), ecorePackage.getEString(), "version", null, 0, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeatureConfiguration_Description(), ecorePackage.getEString(), "description", null, 0, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeatureConfiguration_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeatureConfiguration_FeatureModel(), theFeatureModelPackage.getFeatureModel(), null, "featureModel", null, 0, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeatureConfiguration_FeatureModelCopy(), theFeatureModelPackage.getFeatureModel(), null, "featureModelCopy", null, 1, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeatureConfiguration_Root(), this.getSelection(), null, "root", null, 1, 1, FeatureConfiguration.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        EOperation op = addEOperation(featureConfigurationEClass, null, "getSelectionsById", 0, 1, IS_UNIQUE, IS_ORDERED);
-        addEParameter(op, ecorePackage.getEString(), "id", 0, 1, IS_UNIQUE, IS_ORDERED);
-        EGenericType g1 = createEGenericType(ecorePackage.getEEList());
-        EGenericType g2 = createEGenericType(this.getSelection());
-        g1.getETypeArguments().add(g2);
-        initEOperation(op, g1);
+		EOperation op = addEOperation(featureConfigurationEClass, null, "getSelectionsById", 0, 1, IS_UNIQUE, IS_ORDERED);
+		addEParameter(op, ecorePackage.getEString(), "id", 0, 1, IS_UNIQUE, IS_ORDERED);
+		EGenericType g1 = createEGenericType(ecorePackage.getEEList());
+		EGenericType g2 = createEGenericType(this.getSelection());
+		g1.getETypeArguments().add(g2);
+		initEOperation(op, g1);
 
-        initEClass(selectionEClass, Selection.class, "Selection", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getSelection_Id(), ecorePackage.getEString(), "id", null, 1, 1, Selection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getSelection_Name(), ecorePackage.getEString(), "name", null, 1, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getSelection_Description(), ecorePackage.getEString(), "description", null, 0, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getSelection_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEReference(getSelection_Parent(), this.getSelection(), this.getSelection_Selections(), "parent", null, 0, 1, Selection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getSelection_Root(), ecorePackage.getEBoolean(), "root", null, 1, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getSelection_Present(), ecorePackage.getEBoolean(), "present", null, 0, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getSelection_Enabled(), ecorePackage.getEBoolean(), "enabled", "true", 1, 1, Selection.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getSelection_Values(), this.getAttributeValue(), this.getAttributeValue_Selection(), "values", null, 0, -1, Selection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getSelection_Selections(), this.getSelection(), this.getSelection_Parent(), "selections", null, 0, -1, Selection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getSelection_FeatureConfiguration(), this.getFeatureConfiguration(), null, "featureConfiguration", null, 1, 1, Selection.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEReference(getSelection_Feature(), theFeatureModelPackage.getFeature(), null, "feature", null, 1, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEClass(selectionEClass, Selection.class, "Selection", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getSelection_Id(), ecorePackage.getEString(), "id", null, 1, 1, Selection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getSelection_Name(), ecorePackage.getEString(), "name", null, 1, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getSelection_Description(), ecorePackage.getEString(), "description", null, 0, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getSelection_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEReference(getSelection_Parent(), this.getSelection(), this.getSelection_Selections(), "parent", null, 0, 1, Selection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getSelection_Root(), ecorePackage.getEBoolean(), "root", null, 1, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getSelection_Present(), ecorePackage.getEBoolean(), "present", null, 0, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getSelection_Enabled(), ecorePackage.getEBoolean(), "enabled", "true", 1, 1, Selection.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getSelection_Values(), this.getAttributeValue(), this.getAttributeValue_Selection(), "values", null, 0, -1, Selection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getSelection_Selections(), this.getSelection(), this.getSelection_Parent(), "selections", null, 0, -1, Selection.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getSelection_FeatureConfiguration(), this.getFeatureConfiguration(), null, "featureConfiguration", null, 1, 1, Selection.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEReference(getSelection_Feature(), theFeatureModelPackage.getFeature(), null, "feature", null, 1, 1, Selection.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 
-        initEClass(attributeValueEClass, AttributeValue.class, "AttributeValue", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getAttributeValue_Id(), ecorePackage.getEString(), "id", null, 1, 1, AttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getAttributeValue_Name(), ecorePackage.getEString(), "name", null, 1, 1, AttributeValue.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getAttributeValue_Description(), ecorePackage.getEString(), "description", null, 0, 1, AttributeValue.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getAttributeValue_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, AttributeValue.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEReference(getAttributeValue_Selection(), this.getSelection(), this.getSelection_Values(), "selection", null, 1, 1, AttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getAttributeValue_Attribute(), theFeatureModelPackage.getAttribute(), null, "attribute", null, 1, 1, AttributeValue.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEClass(attributeValueEClass, AttributeValue.class, "AttributeValue", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getAttributeValue_Id(), ecorePackage.getEString(), "id", null, 1, 1, AttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getAttributeValue_Name(), ecorePackage.getEString(), "name", null, 1, 1, AttributeValue.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getAttributeValue_Description(), ecorePackage.getEString(), "description", null, 0, 1, AttributeValue.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getAttributeValue_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, AttributeValue.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEReference(getAttributeValue_Selection(), this.getSelection(), this.getSelection_Values(), "selection", null, 1, 1, AttributeValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getAttributeValue_Attribute(), theFeatureModelPackage.getAttribute(), null, "attribute", null, 1, 1, AttributeValue.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 
-        initEClass(booleanValueEClass, BooleanValue.class, "BooleanValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getBooleanValue_Value(), ecorePackage.getEBoolean(), "value", "false", 1, 1, BooleanValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(booleanValueEClass, BooleanValue.class, "BooleanValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getBooleanValue_Value(), ecorePackage.getEBoolean(), "value", "false", 1, 1, BooleanValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(integerValueEClass, IntegerValue.class, "IntegerValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getIntegerValue_Value(), ecorePackage.getEInt(), "value", "0", 1, 1, IntegerValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(integerValueEClass, IntegerValue.class, "IntegerValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getIntegerValue_Value(), ecorePackage.getEInt(), "value", "0", 1, 1, IntegerValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(doubleValueEClass, DoubleValue.class, "DoubleValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getDoubleValue_Value(), ecorePackage.getEDouble(), "value", "0.0", 1, 1, DoubleValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(doubleValueEClass, DoubleValue.class, "DoubleValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getDoubleValue_Value(), ecorePackage.getEDouble(), "value", "0.0", 1, 1, DoubleValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(stringValueEClass, StringValue.class, "StringValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getStringValue_Value(), ecorePackage.getEString(), "value", "", 1, 1, StringValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(stringValueEClass, StringValue.class, "StringValue", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getStringValue_Value(), ecorePackage.getEString(), "value", "", 1, 1, StringValue.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        // Create resource
-        createResource(eNS_URI);
-    }
+		// Create resource
+		createResource(eNS_URI);
+	}
 
 } //FeatureConfigurationPackageImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/IntegerValueImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/IntegerValueImpl.java
@@ -15,146 +15,146 @@ import cz.zcu.yafmt.model.fc.IntegerValue;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.IntegerValueImpl#getValue <em>Value</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class IntegerValueImpl extends AttributeValueImpl implements IntegerValue {
     /**
-     * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
     protected static final int VALUE_EDEFAULT = 0;
 
     /**
-     * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
     protected int value = VALUE_EDEFAULT;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected IntegerValueImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureConfigurationPackage.Literals.INTEGER_VALUE;
-    }
+		return FeatureConfigurationPackage.Literals.INTEGER_VALUE;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public int getValue() {
-        return value;
-    }
+		return value;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setValue(int newValue) {
-        int oldValue = value;
-        value = newValue;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.INTEGER_VALUE__VALUE, oldValue, value));
-    }
+		int oldValue = value;
+		value = newValue;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.INTEGER_VALUE__VALUE, oldValue, value));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
-                return getValue();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
+				return getValue();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
-                setValue((Integer)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
+				setValue((Integer)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
-                setValue(VALUE_EDEFAULT);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
+				setValue(VALUE_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
-                return value != VALUE_EDEFAULT;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.INTEGER_VALUE__VALUE:
+				return value != VALUE_EDEFAULT;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (value: ");
-        result.append(value);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (value: ");
+		result.append(value);
+		result.append(')');
+		return result.toString();
+	}
 
 } //IntegerValueImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/SelectionImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/SelectionImpl.java
@@ -30,6 +30,7 @@ import cz.zcu.yafmt.model.fm.Feature;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.SelectionImpl#getId <em>Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.SelectionImpl#getName <em>Name</em>}</li>
@@ -44,170 +45,169 @@ import cz.zcu.yafmt.model.fm.Feature;
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.SelectionImpl#getFeatureConfiguration <em>Feature Configuration</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.SelectionImpl#getFeature <em>Feature</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class SelectionImpl extends EObjectImpl implements Selection {
     /**
-     * The default value of the '{@link #getId() <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String ID_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
     protected String id = ID_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String NAME_EDEFAULT = null;
 
     /**
-     * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String DESCRIPTION_EDEFAULT = null;
 
     /**
-     * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String COMMENT_EDEFAULT = null;
 
     /**
-     * The default value of the '{@link #isRoot() <em>Root</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isRoot() <em>Root</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isRoot()
-     * @generated
-     * @ordered
-     */
+	 * @see #isRoot()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean ROOT_EDEFAULT = false;
 
     /**
-     * The default value of the '{@link #isPresent() <em>Present</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isPresent() <em>Present</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isPresent()
-     * @generated
-     * @ordered
-     */
+	 * @see #isPresent()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean PRESENT_EDEFAULT = false;
 
     /**
-     * The default value of the '{@link #isEnabled() <em>Enabled</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isEnabled() <em>Enabled</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isEnabled()
-     * @generated
-     * @ordered
-     */
+	 * @see #isEnabled()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean ENABLED_EDEFAULT = true;
 
     /**
-     * The cached value of the '{@link #isEnabled() <em>Enabled</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #isEnabled() <em>Enabled</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isEnabled()
-     * @generated
-     * @ordered
-     */
+	 * @see #isEnabled()
+	 * @generated
+	 * @ordered
+	 */
     protected boolean enabled = ENABLED_EDEFAULT;
 
     /**
-     * The cached value of the '{@link #getValues() <em>Values</em>}' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getValues() <em>Values</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getValues()
-     * @generated
-     * @ordered
-     */
+	 * @see #getValues()
+	 * @generated
+	 * @ordered
+	 */
     protected EList<AttributeValue> values;
 
     /**
-     * The cached value of the '{@link #getSelections() <em>Selections</em>}' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getSelections() <em>Selections</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getSelections()
-     * @generated
-     * @ordered
-     */
+	 * @see #getSelections()
+	 * @generated
+	 * @ordered
+	 */
     protected EList<Selection> selections;
 
     /**
-     * The cached value of the '{@link #getFeatureConfiguration() <em>Feature Configuration</em>}' reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getFeatureConfiguration() <em>Feature Configuration</em>}' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getFeatureConfiguration()
-     * @generated
-     * @ordered
-     */
+	 * @see #getFeatureConfiguration()
+	 * @generated
+	 * @ordered
+	 */
     protected FeatureConfiguration featureConfiguration;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected SelectionImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureConfigurationPackage.Literals.SELECTION;
-    }
+		return FeatureConfigurationPackage.Literals.SELECTION;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getId() {
-        return id;
-    }
+		return id;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setId(String newId) {
-        String oldId = id;
-        id = newId;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.SELECTION__ID, oldId, id));
-    }
+		String oldId = id;
+		id = newId;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.SELECTION__ID, oldId, id));
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -240,45 +240,45 @@ public class SelectionImpl extends EObjectImpl implements Selection {
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Selection getParent() {
-        if (eContainerFeatureID() != FeatureConfigurationPackage.SELECTION__PARENT) return null;
-        return (Selection)eContainer();
-    }
+		if (eContainerFeatureID() != FeatureConfigurationPackage.SELECTION__PARENT) return null;
+		return (Selection)eInternalContainer();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetParent(Selection newParent, NotificationChain msgs) {
-        msgs = eBasicSetContainer((InternalEObject)newParent, FeatureConfigurationPackage.SELECTION__PARENT, msgs);
-        return msgs;
-    }
+		msgs = eBasicSetContainer((InternalEObject)newParent, FeatureConfigurationPackage.SELECTION__PARENT, msgs);
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setParent(Selection newParent) {
-        if (newParent != eInternalContainer() || (eContainerFeatureID() != FeatureConfigurationPackage.SELECTION__PARENT && newParent != null)) {
-            if (EcoreUtil.isAncestor(this, newParent))
-                throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
-            NotificationChain msgs = null;
-            if (eInternalContainer() != null)
-                msgs = eBasicRemoveFromContainer(msgs);
-            if (newParent != null)
-                msgs = ((InternalEObject)newParent).eInverseAdd(this, FeatureConfigurationPackage.SELECTION__SELECTIONS, Selection.class, msgs);
-            msgs = basicSetParent(newParent, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.SELECTION__PARENT, newParent, newParent));
-    }
+		if (newParent != eInternalContainer() || (eContainerFeatureID() != FeatureConfigurationPackage.SELECTION__PARENT && newParent != null)) {
+			if (EcoreUtil.isAncestor(this, newParent))
+				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
+			NotificationChain msgs = null;
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
+			if (newParent != null)
+				msgs = ((InternalEObject)newParent).eInverseAdd(this, FeatureConfigurationPackage.SELECTION__SELECTIONS, Selection.class, msgs);
+			msgs = basicSetParent(newParent, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.SELECTION__PARENT, newParent, newParent));
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -300,49 +300,49 @@ public class SelectionImpl extends EObjectImpl implements Selection {
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public boolean isEnabled() {
-        return enabled;
-    }
+		return enabled;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setEnabled(boolean newEnabled) {
-        boolean oldEnabled = enabled;
-        enabled = newEnabled;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.SELECTION__ENABLED, oldEnabled, enabled));
-    }
+		boolean oldEnabled = enabled;
+		enabled = newEnabled;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.SELECTION__ENABLED, oldEnabled, enabled));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EList<Selection> getSelections() {
-        if (selections == null) {
-            selections = new EObjectContainmentWithInverseEList<Selection>(Selection.class, this, FeatureConfigurationPackage.SELECTION__SELECTIONS, FeatureConfigurationPackage.SELECTION__PARENT);
-        }
-        return selections;
-    }
+		if (selections == null) {
+			selections = new EObjectContainmentWithInverseEList<Selection>(Selection.class, this, FeatureConfigurationPackage.SELECTION__SELECTIONS, FeatureConfigurationPackage.SELECTION__PARENT);
+		}
+		return selections;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EList<AttributeValue> getValues() {
-        if (values == null) {
-            values = new EObjectContainmentWithInverseEList<AttributeValue>(AttributeValue.class, this, FeatureConfigurationPackage.SELECTION__VALUES, FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION);
-        }
-        return values;
-    }
+		if (values == null) {
+			values = new EObjectContainmentWithInverseEList<AttributeValue>(AttributeValue.class, this, FeatureConfigurationPackage.SELECTION__VALUES, FeatureConfigurationPackage.ATTRIBUTE_VALUE__SELECTION);
+		}
+		return values;
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -389,26 +389,26 @@ public class SelectionImpl extends EObjectImpl implements Selection {
     }
     
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setFeatureConfiguration(FeatureConfiguration newFeatureConfiguration) {
-        FeatureConfiguration oldFeatureConfiguration = featureConfiguration;
-        featureConfiguration = newFeatureConfiguration;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION, oldFeatureConfiguration, featureConfiguration));
-    }
+		FeatureConfiguration oldFeatureConfiguration = featureConfiguration;
+		featureConfiguration = newFeatureConfiguration;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION, oldFeatureConfiguration, featureConfiguration));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Feature getFeature() {
-        Feature feature = basicGetFeature();
-        return feature != null && feature.eIsProxy() ? (Feature)eResolveProxy((InternalEObject)feature) : feature;
-    }
+		Feature feature = basicGetFeature();
+		return feature != null && feature.eIsProxy() ? (Feature)eResolveProxy((InternalEObject)feature) : feature;
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -424,211 +424,211 @@ public class SelectionImpl extends EObjectImpl implements Selection {
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @SuppressWarnings("unchecked")
     @Override
     public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.SELECTION__PARENT:
-                if (eInternalContainer() != null)
-                    msgs = eBasicRemoveFromContainer(msgs);
-                return basicSetParent((Selection)otherEnd, msgs);
-            case FeatureConfigurationPackage.SELECTION__VALUES:
-                return ((InternalEList<InternalEObject>)(InternalEList<?>)getValues()).basicAdd(otherEnd, msgs);
-            case FeatureConfigurationPackage.SELECTION__SELECTIONS:
-                return ((InternalEList<InternalEObject>)(InternalEList<?>)getSelections()).basicAdd(otherEnd, msgs);
-        }
-        return super.eInverseAdd(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.SELECTION__PARENT:
+				if (eInternalContainer() != null)
+					msgs = eBasicRemoveFromContainer(msgs);
+				return basicSetParent((Selection)otherEnd, msgs);
+			case FeatureConfigurationPackage.SELECTION__VALUES:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getValues()).basicAdd(otherEnd, msgs);
+			case FeatureConfigurationPackage.SELECTION__SELECTIONS:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getSelections()).basicAdd(otherEnd, msgs);
+		}
+		return super.eInverseAdd(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.SELECTION__PARENT:
-                return basicSetParent(null, msgs);
-            case FeatureConfigurationPackage.SELECTION__VALUES:
-                return ((InternalEList<?>)getValues()).basicRemove(otherEnd, msgs);
-            case FeatureConfigurationPackage.SELECTION__SELECTIONS:
-                return ((InternalEList<?>)getSelections()).basicRemove(otherEnd, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.SELECTION__PARENT:
+				return basicSetParent(null, msgs);
+			case FeatureConfigurationPackage.SELECTION__VALUES:
+				return ((InternalEList<?>)getValues()).basicRemove(otherEnd, msgs);
+			case FeatureConfigurationPackage.SELECTION__SELECTIONS:
+				return ((InternalEList<?>)getSelections()).basicRemove(otherEnd, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eBasicRemoveFromContainerFeature(NotificationChain msgs) {
-        switch (eContainerFeatureID()) {
-            case FeatureConfigurationPackage.SELECTION__PARENT:
-                return eInternalContainer().eInverseRemove(this, FeatureConfigurationPackage.SELECTION__SELECTIONS, Selection.class, msgs);
-        }
-        return super.eBasicRemoveFromContainerFeature(msgs);
-    }
+		switch (eContainerFeatureID()) {
+			case FeatureConfigurationPackage.SELECTION__PARENT:
+				return eInternalContainer().eInverseRemove(this, FeatureConfigurationPackage.SELECTION__SELECTIONS, Selection.class, msgs);
+		}
+		return super.eBasicRemoveFromContainerFeature(msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.SELECTION__ID:
-                return getId();
-            case FeatureConfigurationPackage.SELECTION__NAME:
-                return getName();
-            case FeatureConfigurationPackage.SELECTION__DESCRIPTION:
-                return getDescription();
-            case FeatureConfigurationPackage.SELECTION__COMMENT:
-                return getComment();
-            case FeatureConfigurationPackage.SELECTION__PARENT:
-                return getParent();
-            case FeatureConfigurationPackage.SELECTION__ROOT:
-                return isRoot();
-            case FeatureConfigurationPackage.SELECTION__PRESENT:
-                return isPresent();
-            case FeatureConfigurationPackage.SELECTION__ENABLED:
-                return isEnabled();
-            case FeatureConfigurationPackage.SELECTION__VALUES:
-                return getValues();
-            case FeatureConfigurationPackage.SELECTION__SELECTIONS:
-                return getSelections();
-            case FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION:
-                if (resolve) return getFeatureConfiguration();
-                return basicGetFeatureConfiguration();
-            case FeatureConfigurationPackage.SELECTION__FEATURE:
-                if (resolve) return getFeature();
-                return basicGetFeature();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.SELECTION__ID:
+				return getId();
+			case FeatureConfigurationPackage.SELECTION__NAME:
+				return getName();
+			case FeatureConfigurationPackage.SELECTION__DESCRIPTION:
+				return getDescription();
+			case FeatureConfigurationPackage.SELECTION__COMMENT:
+				return getComment();
+			case FeatureConfigurationPackage.SELECTION__PARENT:
+				return getParent();
+			case FeatureConfigurationPackage.SELECTION__ROOT:
+				return isRoot();
+			case FeatureConfigurationPackage.SELECTION__PRESENT:
+				return isPresent();
+			case FeatureConfigurationPackage.SELECTION__ENABLED:
+				return isEnabled();
+			case FeatureConfigurationPackage.SELECTION__VALUES:
+				return getValues();
+			case FeatureConfigurationPackage.SELECTION__SELECTIONS:
+				return getSelections();
+			case FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION:
+				if (resolve) return getFeatureConfiguration();
+				return basicGetFeatureConfiguration();
+			case FeatureConfigurationPackage.SELECTION__FEATURE:
+				if (resolve) return getFeature();
+				return basicGetFeature();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @SuppressWarnings("unchecked")
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.SELECTION__ID:
-                setId((String)newValue);
-                return;
-            case FeatureConfigurationPackage.SELECTION__PARENT:
-                setParent((Selection)newValue);
-                return;
-            case FeatureConfigurationPackage.SELECTION__ENABLED:
-                setEnabled((Boolean)newValue);
-                return;
-            case FeatureConfigurationPackage.SELECTION__VALUES:
-                getValues().clear();
-                getValues().addAll((Collection<? extends AttributeValue>)newValue);
-                return;
-            case FeatureConfigurationPackage.SELECTION__SELECTIONS:
-                getSelections().clear();
-                getSelections().addAll((Collection<? extends Selection>)newValue);
-                return;
-            case FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION:
-                setFeatureConfiguration((FeatureConfiguration)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.SELECTION__ID:
+				setId((String)newValue);
+				return;
+			case FeatureConfigurationPackage.SELECTION__PARENT:
+				setParent((Selection)newValue);
+				return;
+			case FeatureConfigurationPackage.SELECTION__ENABLED:
+				setEnabled((Boolean)newValue);
+				return;
+			case FeatureConfigurationPackage.SELECTION__VALUES:
+				getValues().clear();
+				getValues().addAll((Collection<? extends AttributeValue>)newValue);
+				return;
+			case FeatureConfigurationPackage.SELECTION__SELECTIONS:
+				getSelections().clear();
+				getSelections().addAll((Collection<? extends Selection>)newValue);
+				return;
+			case FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION:
+				setFeatureConfiguration((FeatureConfiguration)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.SELECTION__ID:
-                setId(ID_EDEFAULT);
-                return;
-            case FeatureConfigurationPackage.SELECTION__PARENT:
-                setParent((Selection)null);
-                return;
-            case FeatureConfigurationPackage.SELECTION__ENABLED:
-                setEnabled(ENABLED_EDEFAULT);
-                return;
-            case FeatureConfigurationPackage.SELECTION__VALUES:
-                getValues().clear();
-                return;
-            case FeatureConfigurationPackage.SELECTION__SELECTIONS:
-                getSelections().clear();
-                return;
-            case FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION:
-                setFeatureConfiguration((FeatureConfiguration)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.SELECTION__ID:
+				setId(ID_EDEFAULT);
+				return;
+			case FeatureConfigurationPackage.SELECTION__PARENT:
+				setParent((Selection)null);
+				return;
+			case FeatureConfigurationPackage.SELECTION__ENABLED:
+				setEnabled(ENABLED_EDEFAULT);
+				return;
+			case FeatureConfigurationPackage.SELECTION__VALUES:
+				getValues().clear();
+				return;
+			case FeatureConfigurationPackage.SELECTION__SELECTIONS:
+				getSelections().clear();
+				return;
+			case FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION:
+				setFeatureConfiguration((FeatureConfiguration)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.SELECTION__ID:
-                return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
-            case FeatureConfigurationPackage.SELECTION__NAME:
-                return NAME_EDEFAULT == null ? getName() != null : !NAME_EDEFAULT.equals(getName());
-            case FeatureConfigurationPackage.SELECTION__DESCRIPTION:
-                return DESCRIPTION_EDEFAULT == null ? getDescription() != null : !DESCRIPTION_EDEFAULT.equals(getDescription());
-            case FeatureConfigurationPackage.SELECTION__COMMENT:
-                return COMMENT_EDEFAULT == null ? getComment() != null : !COMMENT_EDEFAULT.equals(getComment());
-            case FeatureConfigurationPackage.SELECTION__PARENT:
-                return getParent() != null;
-            case FeatureConfigurationPackage.SELECTION__ROOT:
-                return isRoot() != ROOT_EDEFAULT;
-            case FeatureConfigurationPackage.SELECTION__PRESENT:
-                return isPresent() != PRESENT_EDEFAULT;
-            case FeatureConfigurationPackage.SELECTION__ENABLED:
-                return enabled != ENABLED_EDEFAULT;
-            case FeatureConfigurationPackage.SELECTION__VALUES:
-                return values != null && !values.isEmpty();
-            case FeatureConfigurationPackage.SELECTION__SELECTIONS:
-                return selections != null && !selections.isEmpty();
-            case FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION:
-                return featureConfiguration != null;
-            case FeatureConfigurationPackage.SELECTION__FEATURE:
-                return basicGetFeature() != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.SELECTION__ID:
+				return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
+			case FeatureConfigurationPackage.SELECTION__NAME:
+				return NAME_EDEFAULT == null ? getName() != null : !NAME_EDEFAULT.equals(getName());
+			case FeatureConfigurationPackage.SELECTION__DESCRIPTION:
+				return DESCRIPTION_EDEFAULT == null ? getDescription() != null : !DESCRIPTION_EDEFAULT.equals(getDescription());
+			case FeatureConfigurationPackage.SELECTION__COMMENT:
+				return COMMENT_EDEFAULT == null ? getComment() != null : !COMMENT_EDEFAULT.equals(getComment());
+			case FeatureConfigurationPackage.SELECTION__PARENT:
+				return getParent() != null;
+			case FeatureConfigurationPackage.SELECTION__ROOT:
+				return isRoot() != ROOT_EDEFAULT;
+			case FeatureConfigurationPackage.SELECTION__PRESENT:
+				return isPresent() != PRESENT_EDEFAULT;
+			case FeatureConfigurationPackage.SELECTION__ENABLED:
+				return enabled != ENABLED_EDEFAULT;
+			case FeatureConfigurationPackage.SELECTION__VALUES:
+				return values != null && !values.isEmpty();
+			case FeatureConfigurationPackage.SELECTION__SELECTIONS:
+				return selections != null && !selections.isEmpty();
+			case FeatureConfigurationPackage.SELECTION__FEATURE_CONFIGURATION:
+				return featureConfiguration != null;
+			case FeatureConfigurationPackage.SELECTION__FEATURE:
+				return basicGetFeature() != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (id: ");
-        result.append(id);
-        result.append(", enabled: ");
-        result.append(enabled);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (id: ");
+		result.append(id);
+		result.append(", enabled: ");
+		result.append(enabled);
+		result.append(')');
+		return result.toString();
+	}
 
 } //SelectionImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/StringValueImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/impl/StringValueImpl.java
@@ -15,146 +15,146 @@ import cz.zcu.yafmt.model.fc.StringValue;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fc.impl.StringValueImpl#getValue <em>Value</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class StringValueImpl extends AttributeValueImpl implements StringValue {
     /**
-     * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String VALUE_EDEFAULT = "";
 
     /**
-     * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
     protected String value = VALUE_EDEFAULT;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected StringValueImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureConfigurationPackage.Literals.STRING_VALUE;
-    }
+		return FeatureConfigurationPackage.Literals.STRING_VALUE;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getValue() {
-        return value;
-    }
+		return value;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setValue(String newValue) {
-        String oldValue = value;
-        value = newValue;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.STRING_VALUE__VALUE, oldValue, value));
-    }
+		String oldValue = value;
+		value = newValue;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureConfigurationPackage.STRING_VALUE__VALUE, oldValue, value));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.STRING_VALUE__VALUE:
-                return getValue();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.STRING_VALUE__VALUE:
+				return getValue();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.STRING_VALUE__VALUE:
-                setValue((String)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.STRING_VALUE__VALUE:
+				setValue((String)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.STRING_VALUE__VALUE:
-                setValue(VALUE_EDEFAULT);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.STRING_VALUE__VALUE:
+				setValue(VALUE_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureConfigurationPackage.STRING_VALUE__VALUE:
-                return VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureConfigurationPackage.STRING_VALUE__VALUE:
+				return VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (value: ");
-        result.append(value);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (value: ");
+		result.append(value);
+		result.append(')');
+		return result.toString();
+	}
 
 } //StringValueImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/util/FeatureConfigurationAdapterFactory.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/util/FeatureConfigurationAdapterFactory.java
@@ -21,85 +21,85 @@ import org.eclipse.emf.ecore.EObject;
  */
 public class FeatureConfigurationAdapterFactory extends AdapterFactoryImpl {
     /**
-     * The cached model package.
-     * <!-- begin-user-doc -->
+	 * The cached model package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected static FeatureConfigurationPackage modelPackage;
 
     /**
-     * Creates an instance of the adapter factory.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the adapter factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureConfigurationAdapterFactory() {
-        if (modelPackage == null) {
-            modelPackage = FeatureConfigurationPackage.eINSTANCE;
-        }
-    }
+		if (modelPackage == null) {
+			modelPackage = FeatureConfigurationPackage.eINSTANCE;
+		}
+	}
 
     /**
-     * Returns whether this factory is applicable for the type of the object.
-     * <!-- begin-user-doc -->
+	 * Returns whether this factory is applicable for the type of the object.
+	 * <!-- begin-user-doc -->
      * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
      * <!-- end-user-doc -->
-     * @return whether this factory is applicable for the type of the object.
-     * @generated
-     */
+	 * @return whether this factory is applicable for the type of the object.
+	 * @generated
+	 */
     @Override
     public boolean isFactoryForType(Object object) {
-        if (object == modelPackage) {
-            return true;
-        }
-        if (object instanceof EObject) {
-            return ((EObject)object).eClass().getEPackage() == modelPackage;
-        }
-        return false;
-    }
+		if (object == modelPackage) {
+			return true;
+		}
+		if (object instanceof EObject) {
+			return ((EObject)object).eClass().getEPackage() == modelPackage;
+		}
+		return false;
+	}
 
     /**
-     * The switch that delegates to the <code>createXXX</code> methods.
-     * <!-- begin-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected FeatureConfigurationSwitch<Adapter> modelSwitch =
         new FeatureConfigurationSwitch<Adapter>() {
-            @Override
-            public Adapter caseFeatureConfiguration(FeatureConfiguration object) {
-                return createFeatureConfigurationAdapter();
-            }
-            @Override
-            public Adapter caseSelection(Selection object) {
-                return createSelectionAdapter();
-            }
-            @Override
-            public Adapter caseAttributeValue(AttributeValue object) {
-                return createAttributeValueAdapter();
-            }
-            @Override
-            public Adapter caseBooleanValue(BooleanValue object) {
-                return createBooleanValueAdapter();
-            }
-            @Override
-            public Adapter caseIntegerValue(IntegerValue object) {
-                return createIntegerValueAdapter();
-            }
-            @Override
-            public Adapter caseDoubleValue(DoubleValue object) {
-                return createDoubleValueAdapter();
-            }
-            @Override
-            public Adapter caseStringValue(StringValue object) {
-                return createStringValueAdapter();
-            }
-            @Override
-            public Adapter defaultCase(EObject object) {
-                return createEObjectAdapter();
-            }
-        };
+			@Override
+			public Adapter caseFeatureConfiguration(FeatureConfiguration object) {
+				return createFeatureConfigurationAdapter();
+			}
+			@Override
+			public Adapter caseSelection(Selection object) {
+				return createSelectionAdapter();
+			}
+			@Override
+			public Adapter caseAttributeValue(AttributeValue object) {
+				return createAttributeValueAdapter();
+			}
+			@Override
+			public Adapter caseBooleanValue(BooleanValue object) {
+				return createBooleanValueAdapter();
+			}
+			@Override
+			public Adapter caseIntegerValue(IntegerValue object) {
+				return createIntegerValueAdapter();
+			}
+			@Override
+			public Adapter caseDoubleValue(DoubleValue object) {
+				return createDoubleValueAdapter();
+			}
+			@Override
+			public Adapter caseStringValue(StringValue object) {
+				return createStringValueAdapter();
+			}
+			@Override
+			public Adapter defaultCase(EObject object) {
+				return createEObjectAdapter();
+			}
+		};
 
     /**
      * Creates an adapter for the <code>target</code>.
@@ -119,113 +119,113 @@ public class FeatureConfigurationAdapterFactory extends AdapterFactoryImpl {
 
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration <em>Feature Configuration</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.FeatureConfiguration <em>Feature Configuration</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fc.FeatureConfiguration
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fc.FeatureConfiguration
+	 * @generated
+	 */
     public Adapter createFeatureConfigurationAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.Selection <em>Selection</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.Selection <em>Selection</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fc.Selection
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fc.Selection
+	 * @generated
+	 */
     public Adapter createSelectionAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.AttributeValue <em>Attribute Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.AttributeValue <em>Attribute Value</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fc.AttributeValue
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fc.AttributeValue
+	 * @generated
+	 */
     public Adapter createAttributeValueAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.BooleanValue <em>Boolean Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.BooleanValue <em>Boolean Value</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fc.BooleanValue
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fc.BooleanValue
+	 * @generated
+	 */
     public Adapter createBooleanValueAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.IntegerValue <em>Integer Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.IntegerValue <em>Integer Value</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fc.IntegerValue
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fc.IntegerValue
+	 * @generated
+	 */
     public Adapter createIntegerValueAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.DoubleValue <em>Double Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.DoubleValue <em>Double Value</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fc.DoubleValue
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fc.DoubleValue
+	 * @generated
+	 */
     public Adapter createDoubleValueAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.StringValue <em>String Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fc.StringValue <em>String Value</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fc.StringValue
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fc.StringValue
+	 * @generated
+	 */
     public Adapter createStringValueAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for the default case.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for the default case.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @generated
+	 */
     public Adapter createEObjectAdapter() {
-        return null;
-    }
+		return null;
+	}
 
 } //FeatureConfigurationAdapterFactory

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/util/FeatureConfigurationSwitch.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fc/util/FeatureConfigurationSwitch.java
@@ -24,217 +24,217 @@ import org.eclipse.emf.ecore.util.Switch;
  */
 public class FeatureConfigurationSwitch<T> extends Switch<T> {
     /**
-     * The cached model package
-     * <!-- begin-user-doc -->
+	 * The cached model package
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected static FeatureConfigurationPackage modelPackage;
 
     /**
-     * Creates an instance of the switch.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the switch.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureConfigurationSwitch() {
-        if (modelPackage == null) {
-            modelPackage = FeatureConfigurationPackage.eINSTANCE;
-        }
-    }
+		if (modelPackage == null) {
+			modelPackage = FeatureConfigurationPackage.eINSTANCE;
+		}
+	}
 
     /**
-     * Checks whether this is a switch for the given package.
-     * <!-- begin-user-doc -->
+	 * Checks whether this is a switch for the given package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @parameter ePackage the package in question.
-     * @return whether this is a switch for the given package.
-     * @generated
-     */
+	 * @param ePackage the package in question.
+	 * @return whether this is a switch for the given package.
+	 * @generated
+	 */
     @Override
     protected boolean isSwitchFor(EPackage ePackage) {
-        return ePackage == modelPackage;
-    }
+		return ePackage == modelPackage;
+	}
 
     /**
-     * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-     * <!-- begin-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the first non-null result returned by a <code>caseXXX</code> call.
-     * @generated
-     */
+	 * @return the first non-null result returned by a <code>caseXXX</code> call.
+	 * @generated
+	 */
     @Override
     protected T doSwitch(int classifierID, EObject theEObject) {
-        switch (classifierID) {
-            case FeatureConfigurationPackage.FEATURE_CONFIGURATION: {
-                FeatureConfiguration featureConfiguration = (FeatureConfiguration)theEObject;
-                T result = caseFeatureConfiguration(featureConfiguration);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureConfigurationPackage.SELECTION: {
-                Selection selection = (Selection)theEObject;
-                T result = caseSelection(selection);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureConfigurationPackage.ATTRIBUTE_VALUE: {
-                AttributeValue attributeValue = (AttributeValue)theEObject;
-                T result = caseAttributeValue(attributeValue);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureConfigurationPackage.BOOLEAN_VALUE: {
-                BooleanValue booleanValue = (BooleanValue)theEObject;
-                T result = caseBooleanValue(booleanValue);
-                if (result == null) result = caseAttributeValue(booleanValue);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureConfigurationPackage.INTEGER_VALUE: {
-                IntegerValue integerValue = (IntegerValue)theEObject;
-                T result = caseIntegerValue(integerValue);
-                if (result == null) result = caseAttributeValue(integerValue);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureConfigurationPackage.DOUBLE_VALUE: {
-                DoubleValue doubleValue = (DoubleValue)theEObject;
-                T result = caseDoubleValue(doubleValue);
-                if (result == null) result = caseAttributeValue(doubleValue);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureConfigurationPackage.STRING_VALUE: {
-                StringValue stringValue = (StringValue)theEObject;
-                T result = caseStringValue(stringValue);
-                if (result == null) result = caseAttributeValue(stringValue);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            default: return defaultCase(theEObject);
-        }
-    }
+		switch (classifierID) {
+			case FeatureConfigurationPackage.FEATURE_CONFIGURATION: {
+				FeatureConfiguration featureConfiguration = (FeatureConfiguration)theEObject;
+				T result = caseFeatureConfiguration(featureConfiguration);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureConfigurationPackage.SELECTION: {
+				Selection selection = (Selection)theEObject;
+				T result = caseSelection(selection);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureConfigurationPackage.ATTRIBUTE_VALUE: {
+				AttributeValue attributeValue = (AttributeValue)theEObject;
+				T result = caseAttributeValue(attributeValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureConfigurationPackage.BOOLEAN_VALUE: {
+				BooleanValue booleanValue = (BooleanValue)theEObject;
+				T result = caseBooleanValue(booleanValue);
+				if (result == null) result = caseAttributeValue(booleanValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureConfigurationPackage.INTEGER_VALUE: {
+				IntegerValue integerValue = (IntegerValue)theEObject;
+				T result = caseIntegerValue(integerValue);
+				if (result == null) result = caseAttributeValue(integerValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureConfigurationPackage.DOUBLE_VALUE: {
+				DoubleValue doubleValue = (DoubleValue)theEObject;
+				T result = caseDoubleValue(doubleValue);
+				if (result == null) result = caseAttributeValue(doubleValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureConfigurationPackage.STRING_VALUE: {
+				StringValue stringValue = (StringValue)theEObject;
+				T result = caseStringValue(stringValue);
+				if (result == null) result = caseAttributeValue(stringValue);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			default: return defaultCase(theEObject);
+		}
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Feature Configuration</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Feature Configuration</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Feature Configuration</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Feature Configuration</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseFeatureConfiguration(FeatureConfiguration object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Selection</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Selection</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Selection</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Selection</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseSelection(Selection object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Attribute Value</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Attribute Value</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Attribute Value</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Attribute Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseAttributeValue(AttributeValue object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Boolean Value</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Boolean Value</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Boolean Value</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Boolean Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseBooleanValue(BooleanValue object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Integer Value</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Integer Value</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Integer Value</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Integer Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseIntegerValue(IntegerValue object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Double Value</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Double Value</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Double Value</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Double Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseDoubleValue(DoubleValue object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>String Value</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>String Value</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>String Value</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>String Value</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseStringValue(StringValue object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch, but this is the last case anyway.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
+	 * @generated
+	 */
     @Override
     public T defaultCase(EObject object) {
-        return null;
-    }
+		return null;
+	}
 
 } //FeatureConfigurationSwitch

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/Attribute.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/Attribute.java
@@ -11,15 +11,16 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.Attribute#getId <em>Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Attribute#getName <em>Name</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Attribute#getType <em>Type</em>}</li>
+ *   <li>{@link cz.zcu.yafmt.model.fm.Attribute#getValue <em>Value</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Attribute#getDescription <em>Description</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Attribute#getComment <em>Comment</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Attribute#getFeature <em>Feature</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute()
  * @model
@@ -27,165 +28,191 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface Attribute extends EObject {
     /**
-     * Returns the value of the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Id</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Id</em>' attribute.
-     * @see #setId(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Id()
-     * @model id="true" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Id</em>' attribute.
+	 * @see #setId(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Id()
+	 * @model id="true" required="true"
+	 * @generated
+	 */
     String getId();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getId <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getId <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Id</em>' attribute.
-     * @see #getId()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Id</em>' attribute.
+	 * @see #getId()
+	 * @generated
+	 */
     void setId(String value);
 
     /**
-     * Returns the value of the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Name</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Name</em>' attribute.
-     * @see #setName(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Name()
-     * @model required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Name</em>' attribute.
+	 * @see #setName(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Name()
+	 * @model required="true"
+	 * @generated
+	 */
     String getName();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getName <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getName <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Name</em>' attribute.
-     * @see #getName()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Name</em>' attribute.
+	 * @see #getName()
+	 * @generated
+	 */
     void setName(String value);
 
     /**
-     * Returns the value of the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Description</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Description</em>' attribute.
-     * @see #setDescription(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Description()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Description</em>' attribute.
+	 * @see #setDescription(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Description()
+	 * @model
+	 * @generated
+	 */
     String getDescription();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getDescription <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getDescription <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Description</em>' attribute.
-     * @see #getDescription()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Description</em>' attribute.
+	 * @see #getDescription()
+	 * @generated
+	 */
     void setDescription(String value);
 
     /**
-     * Returns the value of the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Comment</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Comment</em>' attribute.
-     * @see #setComment(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Comment()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Comment</em>' attribute.
+	 * @see #setComment(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Comment()
+	 * @model
+	 * @generated
+	 */
     String getComment();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getComment <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getComment <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Comment</em>' attribute.
-     * @see #getComment()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Comment</em>' attribute.
+	 * @see #getComment()
+	 * @generated
+	 */
     void setComment(String value);
 
     /**
-     * Returns the value of the '<em><b>Feature</b></em>' container reference.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getAttributes <em>Attributes</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Feature</b></em>' container reference.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getAttributes <em>Attributes</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Feature</em>' reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Feature</em>' container reference.
-     * @see #setFeature(Feature)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Feature()
-     * @see cz.zcu.yafmt.model.fm.Feature#getAttributes
-     * @model opposite="attributes" required="true" transient="false"
-     * @generated
-     */
+	 * @return the value of the '<em>Feature</em>' container reference.
+	 * @see #setFeature(Feature)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Feature()
+	 * @see cz.zcu.yafmt.model.fm.Feature#getAttributes
+	 * @model opposite="attributes" required="true" transient="false"
+	 * @generated
+	 */
     Feature getFeature();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getFeature <em>Feature</em>}' container reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getFeature <em>Feature</em>}' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Feature</em>' container reference.
-     * @see #getFeature()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Feature</em>' container reference.
+	 * @see #getFeature()
+	 * @generated
+	 */
     void setFeature(Feature value);
 
     /**
-     * Returns the value of the '<em><b>Type</b></em>' attribute.
-     * The default value is <code>"BOOLEAN"</code>.
-     * The literals are from the enumeration {@link cz.zcu.yafmt.model.fm.AttributeType}.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Type</b></em>' attribute.
+	 * The default value is <code>"boolean"</code>.
+	 * The literals are from the enumeration {@link cz.zcu.yafmt.model.fm.AttributeType}.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Type</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Type</em>' attribute.
-     * @see cz.zcu.yafmt.model.fm.AttributeType
-     * @see #setType(AttributeType)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Type()
-     * @model default="BOOLEAN" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Type</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fm.AttributeType
+	 * @see #setType(AttributeType)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Type()
+	 * @model default="boolean" required="true"
+	 * @generated
+	 */
     AttributeType getType();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getType <em>Type</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getType <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Type</em>' attribute.
-     * @see cz.zcu.yafmt.model.fm.AttributeType
-     * @see #getType()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Type</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fm.AttributeType
+	 * @see #getType()
+	 * @generated
+	 */
     void setType(AttributeType value);
+
+				/**
+	 * Returns the value of the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Value</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Value</em>' attribute.
+	 * @see #setValue(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getAttribute_Value()
+	 * @model required="true"
+	 * @generated
+	 */
+	String getValue();
+
+				/**
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Attribute#getValue <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Value</em>' attribute.
+	 * @see #getValue()
+	 * @generated
+	 */
+	void setValue(String value);
 
 } // Attribute

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/AttributeType.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/AttributeType.java
@@ -19,244 +19,250 @@ import org.eclipse.emf.common.util.Enumerator;
  */
 public enum AttributeType implements Enumerator {
     /**
-     * The '<em><b>BOOLEAN</b></em>' literal object.
-     * <!-- begin-user-doc -->
+	 * The '<em><b>BOOLEAN</b></em>' literal object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #BOOLEAN_VALUE
-     * @generated
-     * @ordered
-     */
+	 * @see #BOOLEAN_VALUE
+	 * @generated
+	 * @ordered
+	 */
     BOOLEAN(0, "BOOLEAN", "boolean"),
 
     /**
-     * The '<em><b>INTEGER</b></em>' literal object.
-     * <!-- begin-user-doc -->
+	 * The '<em><b>INTEGER</b></em>' literal object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #INTEGER_VALUE
-     * @generated
-     * @ordered
-     */
+	 * @see #INTEGER_VALUE
+	 * @generated
+	 * @ordered
+	 */
     INTEGER(1, "INTEGER", "integer"),
 
     /**
-     * The '<em><b>DOUBLE</b></em>' literal object.
-     * <!-- begin-user-doc -->
+	 * The '<em><b>DOUBLE</b></em>' literal object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #DOUBLE_VALUE
-     * @generated
-     * @ordered
-     */
+	 * @see #DOUBLE_VALUE
+	 * @generated
+	 * @ordered
+	 */
     DOUBLE(2, "DOUBLE", "double"),
 
     /**
-     * The '<em><b>STRING</b></em>' literal object.
-     * <!-- begin-user-doc -->
+	 * The '<em><b>STRING</b></em>' literal object.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #STRING_VALUE
-     * @generated
-     * @ordered
-     */
+	 * @see #STRING_VALUE
+	 * @generated
+	 * @ordered
+	 */
     STRING(3, "STRING", "string");
 
     /**
-     * The '<em><b>BOOLEAN</b></em>' literal value.
-     * <!-- begin-user-doc -->
+	 * The '<em><b>BOOLEAN</b></em>' literal value.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of '<em><b>BOOLEAN</b></em>' literal object isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @see #BOOLEAN
-     * @model literal="boolean"
-     * @generated
-     * @ordered
-     */
+	 * @see #BOOLEAN
+	 * @model literal="boolean"
+	 * @generated
+	 * @ordered
+	 */
     public static final int BOOLEAN_VALUE = 0;
 
     /**
-     * The '<em><b>INTEGER</b></em>' literal value.
-     * <!-- begin-user-doc -->
+	 * The '<em><b>INTEGER</b></em>' literal value.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of '<em><b>INTEGER</b></em>' literal object isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @see #INTEGER
-     * @model literal="integer"
-     * @generated
-     * @ordered
-     */
+	 * @see #INTEGER
+	 * @model literal="integer"
+	 * @generated
+	 * @ordered
+	 */
     public static final int INTEGER_VALUE = 1;
 
     /**
-     * The '<em><b>DOUBLE</b></em>' literal value.
-     * <!-- begin-user-doc -->
+	 * The '<em><b>DOUBLE</b></em>' literal value.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of '<em><b>DOUBLE</b></em>' literal object isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @see #DOUBLE
-     * @model literal="double"
-     * @generated
-     * @ordered
-     */
+	 * @see #DOUBLE
+	 * @model literal="double"
+	 * @generated
+	 * @ordered
+	 */
     public static final int DOUBLE_VALUE = 2;
 
     /**
-     * The '<em><b>STRING</b></em>' literal value.
-     * <!-- begin-user-doc -->
+	 * The '<em><b>STRING</b></em>' literal value.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of '<em><b>STRING</b></em>' literal object isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @see #STRING
-     * @model literal="string"
-     * @generated
-     * @ordered
-     */
+	 * @see #STRING
+	 * @model literal="string"
+	 * @generated
+	 * @ordered
+	 */
     public static final int STRING_VALUE = 3;
 
     /**
-     * An array of all the '<em><b>Attribute Type</b></em>' enumerators.
-     * <!-- begin-user-doc -->
+	 * An array of all the '<em><b>Attribute Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private static final AttributeType[] VALUES_ARRAY =
         new AttributeType[] {
-            BOOLEAN,
-            INTEGER,
-            DOUBLE,
-            STRING,
-        };
+			BOOLEAN,
+			INTEGER,
+			DOUBLE,
+			STRING,
+		};
 
     /**
-     * A public read-only list of all the '<em><b>Attribute Type</b></em>' enumerators.
-     * <!-- begin-user-doc -->
+	 * A public read-only list of all the '<em><b>Attribute Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public static final List<AttributeType> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
     /**
-     * Returns the '<em><b>Attribute Type</b></em>' literal with the specified literal value.
-     * <!-- begin-user-doc -->
+	 * Returns the '<em><b>Attribute Type</b></em>' literal with the specified literal value.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @param literal the literal.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
     public static AttributeType get(String literal) {
-        for (int i = 0; i < VALUES_ARRAY.length; ++i) {
-            AttributeType result = VALUES_ARRAY[i];
-            if (result.toString().equals(literal)) {
-                return result;
-            }
-        }
-        return null;
-    }
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			AttributeType result = VALUES_ARRAY[i];
+			if (result.toString().equals(literal)) {
+				return result;
+			}
+		}
+		return null;
+	}
 
     /**
-     * Returns the '<em><b>Attribute Type</b></em>' literal with the specified name.
-     * <!-- begin-user-doc -->
+	 * Returns the '<em><b>Attribute Type</b></em>' literal with the specified name.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @param name the name.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
     public static AttributeType getByName(String name) {
-        for (int i = 0; i < VALUES_ARRAY.length; ++i) {
-            AttributeType result = VALUES_ARRAY[i];
-            if (result.getName().equals(name)) {
-                return result;
-            }
-        }
-        return null;
-    }
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			AttributeType result = VALUES_ARRAY[i];
+			if (result.getName().equals(name)) {
+				return result;
+			}
+		}
+		return null;
+	}
 
     /**
-     * Returns the '<em><b>Attribute Type</b></em>' literal with the specified integer value.
-     * <!-- begin-user-doc -->
+	 * Returns the '<em><b>Attribute Type</b></em>' literal with the specified integer value.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @param value the integer value.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
     public static AttributeType get(int value) {
-        switch (value) {
-            case BOOLEAN_VALUE: return BOOLEAN;
-            case INTEGER_VALUE: return INTEGER;
-            case DOUBLE_VALUE: return DOUBLE;
-            case STRING_VALUE: return STRING;
-        }
-        return null;
-    }
+		switch (value) {
+			case BOOLEAN_VALUE: return BOOLEAN;
+			case INTEGER_VALUE: return INTEGER;
+			case DOUBLE_VALUE: return DOUBLE;
+			case STRING_VALUE: return STRING;
+		}
+		return null;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private final int value;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private final String name;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private final String literal;
 
     /**
-     * Only this class can construct instances.
-     * <!-- begin-user-doc -->
+	 * Only this class can construct instances.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private AttributeType(int value, String name, String literal) {
-        this.value = value;
-        this.name = name;
-        this.literal = literal;
-    }
+		this.value = value;
+		this.name = name;
+		this.literal = literal;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public int getValue() {
-      return value;
-    }
+	  return value;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getName() {
-      return name;
-    }
+	  return name;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getLiteral() {
-      return literal;
-    }
+	  return literal;
+	}
 
     /**
-     * Returns the literal value of the enumerator, which is its string representation.
-     * <!-- begin-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string representation.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        return literal;
-    }
+		return literal;
+	}
     
 } //AttributeType

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/Constraint.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/Constraint.java
@@ -11,6 +11,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.Constraint#getValue <em>Value</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Constraint#getLanguage <em>Language</em>}</li>
@@ -18,7 +19,6 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link cz.zcu.yafmt.model.fm.Constraint#getComment <em>Comment</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Constraint#getFeatureModel <em>Feature Model</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint()
  * @model
@@ -26,122 +26,122 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface Constraint extends EObject {
     /**
-     * Returns the value of the '<em><b>Value</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Value</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Value</em>' attribute.
-     * @see #setValue(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_Value()
-     * @model required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Value</em>' attribute.
+	 * @see #setValue(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_Value()
+	 * @model required="true"
+	 * @generated
+	 */
     String getValue();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Constraint#getValue <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Constraint#getValue <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Value</em>' attribute.
-     * @see #getValue()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Value</em>' attribute.
+	 * @see #getValue()
+	 * @generated
+	 */
     void setValue(String value);
 
     /**
-     * Returns the value of the '<em><b>Language</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Language</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Language</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Language</em>' attribute.
-     * @see #setLanguage(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_Language()
-     * @model required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Language</em>' attribute.
+	 * @see #setLanguage(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_Language()
+	 * @model required="true"
+	 * @generated
+	 */
     String getLanguage();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Constraint#getLanguage <em>Language</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Constraint#getLanguage <em>Language</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Language</em>' attribute.
-     * @see #getLanguage()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Language</em>' attribute.
+	 * @see #getLanguage()
+	 * @generated
+	 */
     void setLanguage(String value);
 
     /**
-     * Returns the value of the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Description</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Description</em>' attribute.
-     * @see #setDescription(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_Description()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Description</em>' attribute.
+	 * @see #setDescription(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_Description()
+	 * @model
+	 * @generated
+	 */
     String getDescription();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Constraint#getDescription <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Constraint#getDescription <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Description</em>' attribute.
-     * @see #getDescription()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Description</em>' attribute.
+	 * @see #getDescription()
+	 * @generated
+	 */
     void setDescription(String value);
 
     /**
-     * Returns the value of the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Comment</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Comment</em>' attribute.
-     * @see #setComment(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_Comment()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Comment</em>' attribute.
+	 * @see #setComment(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_Comment()
+	 * @model
+	 * @generated
+	 */
     String getComment();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Constraint#getComment <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Constraint#getComment <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Comment</em>' attribute.
-     * @see #getComment()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Comment</em>' attribute.
+	 * @see #getComment()
+	 * @generated
+	 */
     void setComment(String value);
 
     /**
-     * Returns the value of the '<em><b>Feature Model</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Feature Model</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Feature Model</em>' reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Feature Model</em>' reference.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_FeatureModel()
-     * @model transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Feature Model</em>' reference.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getConstraint_FeatureModel()
+	 * @model transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     FeatureModel getFeatureModel();
 
 } // Constraint

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/Feature.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/Feature.java
@@ -13,6 +13,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.Feature#getId <em>Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Feature#getName <em>Name</em>}</li>
@@ -33,7 +34,6 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link cz.zcu.yafmt.model.fm.Feature#getGroups <em>Groups</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Feature#getFeatureModel <em>Feature Model</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature()
  * @model
@@ -41,409 +41,409 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface Feature extends EObject {
     /**
-     * Returns the value of the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Id</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Id</em>' attribute.
-     * @see #setId(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Id()
-     * @model required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Id</em>' attribute.
+	 * @see #setId(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Id()
+	 * @model required="true"
+	 * @generated
+	 */
     String getId();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getId <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getId <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Id</em>' attribute.
-     * @see #getId()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Id</em>' attribute.
+	 * @see #getId()
+	 * @generated
+	 */
     void setId(String value);
 
     /**
-     * Returns the value of the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Name</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Name</em>' attribute.
-     * @see #setName(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Name()
-     * @model required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Name</em>' attribute.
+	 * @see #setName(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Name()
+	 * @model required="true"
+	 * @generated
+	 */
     String getName();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getName <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getName <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Name</em>' attribute.
-     * @see #getName()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Name</em>' attribute.
+	 * @see #getName()
+	 * @generated
+	 */
     void setName(String value);
 
     /**
-     * Returns the value of the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Description</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Description</em>' attribute.
-     * @see #setDescription(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Description()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Description</em>' attribute.
+	 * @see #setDescription(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Description()
+	 * @model
+	 * @generated
+	 */
     String getDescription();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getDescription <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getDescription <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Description</em>' attribute.
-     * @see #getDescription()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Description</em>' attribute.
+	 * @see #getDescription()
+	 * @generated
+	 */
     void setDescription(String value);
 
     /**
-     * Returns the value of the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Comment</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Comment</em>' attribute.
-     * @see #setComment(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Comment()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Comment</em>' attribute.
+	 * @see #setComment(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Comment()
+	 * @model
+	 * @generated
+	 */
     String getComment();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getComment <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getComment <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Comment</em>' attribute.
-     * @see #getComment()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Comment</em>' attribute.
+	 * @see #getComment()
+	 * @generated
+	 */
     void setComment(String value);
 
     /**
-     * Returns the value of the '<em><b>Lower</b></em>' attribute.
-     * The default value is <code>"0"</code>.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Lower</b></em>' attribute.
+	 * The default value is <code>"0"</code>.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Lower</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Lower</em>' attribute.
-     * @see #setLower(int)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Lower()
-     * @model default="0" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Lower</em>' attribute.
+	 * @see #setLower(int)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Lower()
+	 * @model default="0" required="true"
+	 * @generated
+	 */
     int getLower();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getLower <em>Lower</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getLower <em>Lower</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Lower</em>' attribute.
-     * @see #getLower()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Lower</em>' attribute.
+	 * @see #getLower()
+	 * @generated
+	 */
     void setLower(int value);
 
     /**
-     * Returns the value of the '<em><b>Upper</b></em>' attribute.
-     * The default value is <code>"1"</code>.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Upper</b></em>' attribute.
+	 * The default value is <code>"1"</code>.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Upper</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Upper</em>' attribute.
-     * @see #setUpper(int)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Upper()
-     * @model default="1" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Upper</em>' attribute.
+	 * @see #setUpper(int)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Upper()
+	 * @model default="1" required="true"
+	 * @generated
+	 */
     int getUpper();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getUpper <em>Upper</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getUpper <em>Upper</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Upper</em>' attribute.
-     * @see #getUpper()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Upper</em>' attribute.
+	 * @see #getUpper()
+	 * @generated
+	 */
     void setUpper(int value);
 
     /**
-     * Returns the value of the '<em><b>Root</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Root</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Root</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Root</em>' attribute.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Root()
-     * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Root</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Root()
+	 * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     boolean isRoot();
 
     /**
-     * Returns the value of the '<em><b>Orphan</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Orphan</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Orphan</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Orphan</em>' attribute.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Orphan()
-     * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Orphan</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Orphan()
+	 * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     boolean isOrphan();
 
     /**
-     * Returns the value of the '<em><b>Optional</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Optional</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Optional</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Optional</em>' attribute.
-     * @see #setOptional(boolean)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Optional()
-     * @model required="true" transient="true" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Optional</em>' attribute.
+	 * @see #setOptional(boolean)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Optional()
+	 * @model required="true" transient="true" volatile="true" derived="true"
+	 * @generated
+	 */
     boolean isOptional();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#isOptional <em>Optional</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#isOptional <em>Optional</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Optional</em>' attribute.
-     * @see #isOptional()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Optional</em>' attribute.
+	 * @see #isOptional()
+	 * @generated
+	 */
     void setOptional(boolean value);
 
     /**
-     * Returns the value of the '<em><b>Mandatory</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Mandatory</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Mandatory</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Mandatory</em>' attribute.
-     * @see #setMandatory(boolean)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Mandatory()
-     * @model required="true" transient="true" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Mandatory</em>' attribute.
+	 * @see #setMandatory(boolean)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Mandatory()
+	 * @model required="true" transient="true" volatile="true" derived="true"
+	 * @generated
+	 */
     boolean isMandatory();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#isMandatory <em>Mandatory</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#isMandatory <em>Mandatory</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Mandatory</em>' attribute.
-     * @see #isMandatory()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Mandatory</em>' attribute.
+	 * @see #isMandatory()
+	 * @generated
+	 */
     void setMandatory(boolean value);
 
     /**
-     * Returns the value of the '<em><b>Cloneable</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Cloneable</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Cloneable</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Cloneable</em>' attribute.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Cloneable()
-     * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Cloneable</em>' attribute.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Cloneable()
+	 * @model required="true" transient="true" changeable="false" volatile="true" derived="true"
+	 * @generated
+	 */
     boolean isCloneable();
 
     /**
-     * Returns the value of the '<em><b>Attributes</b></em>' containment reference list.
-     * The list contents are of type {@link cz.zcu.yafmt.model.fm.Attribute}.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Attribute#getFeature <em>Feature</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Attributes</b></em>' containment reference list.
+	 * The list contents are of type {@link cz.zcu.yafmt.model.fm.Attribute}.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Attribute#getFeature <em>Feature</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Attributes</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Attributes</em>' containment reference list.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Attributes()
-     * @see cz.zcu.yafmt.model.fm.Attribute#getFeature
-     * @model opposite="feature" containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Attributes</em>' containment reference list.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Attributes()
+	 * @see cz.zcu.yafmt.model.fm.Attribute#getFeature
+	 * @model opposite="feature" containment="true"
+	 * @generated
+	 */
     EList<Attribute> getAttributes();
 
     /**
-     * Returns the value of the '<em><b>Parent</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Parent</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Parent</em>' reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Parent</em>' reference.
-     * @see #setParent(EObject)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Parent()
-     * @model transient="true" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Parent</em>' reference.
+	 * @see #setParent(EObject)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Parent()
+	 * @model transient="true" volatile="true" derived="true"
+	 * @generated
+	 */
     EObject getParent();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getParent <em>Parent</em>}' reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getParent <em>Parent</em>}' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Parent</em>' reference.
-     * @see #getParent()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Parent</em>' reference.
+	 * @see #getParent()
+	 * @generated
+	 */
     void setParent(EObject value);
 
     /**
-     * Returns the value of the '<em><b>Parent Feature</b></em>' container reference.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getFeatures <em>Features</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Parent Feature</b></em>' container reference.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getFeatures <em>Features</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Parent Feature</em>' container reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Parent Feature</em>' container reference.
-     * @see #setParentFeature(Feature)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_ParentFeature()
-     * @see cz.zcu.yafmt.model.fm.Feature#getFeatures
-     * @model opposite="features" transient="false"
-     * @generated
-     */
+	 * @return the value of the '<em>Parent Feature</em>' container reference.
+	 * @see #setParentFeature(Feature)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_ParentFeature()
+	 * @see cz.zcu.yafmt.model.fm.Feature#getFeatures
+	 * @model opposite="features" transient="false"
+	 * @generated
+	 */
     Feature getParentFeature();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getParentFeature <em>Parent Feature</em>}' container reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getParentFeature <em>Parent Feature</em>}' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Parent Feature</em>' container reference.
-     * @see #getParentFeature()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Parent Feature</em>' container reference.
+	 * @see #getParentFeature()
+	 * @generated
+	 */
     void setParentFeature(Feature value);
 
     /**
-     * Returns the value of the '<em><b>Parent Group</b></em>' container reference.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Group#getFeatures <em>Features</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Parent Group</b></em>' container reference.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Group#getFeatures <em>Features</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Parent Group</em>' container reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Parent Group</em>' container reference.
-     * @see #setParentGroup(Group)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_ParentGroup()
-     * @see cz.zcu.yafmt.model.fm.Group#getFeatures
-     * @model opposite="features" transient="false"
-     * @generated
-     */
+	 * @return the value of the '<em>Parent Group</em>' container reference.
+	 * @see #setParentGroup(Group)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_ParentGroup()
+	 * @see cz.zcu.yafmt.model.fm.Group#getFeatures
+	 * @model opposite="features" transient="false"
+	 * @generated
+	 */
     Group getParentGroup();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getParentGroup <em>Parent Group</em>}' container reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Feature#getParentGroup <em>Parent Group</em>}' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Parent Group</em>' container reference.
-     * @see #getParentGroup()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Parent Group</em>' container reference.
+	 * @see #getParentGroup()
+	 * @generated
+	 */
     void setParentGroup(Group value);
 
     /**
-     * Returns the value of the '<em><b>Features</b></em>' containment reference list.
-     * The list contents are of type {@link cz.zcu.yafmt.model.fm.Feature}.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getParentFeature <em>Parent Feature</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Features</b></em>' containment reference list.
+	 * The list contents are of type {@link cz.zcu.yafmt.model.fm.Feature}.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getParentFeature <em>Parent Feature</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Features</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Features</em>' containment reference list.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Features()
-     * @see cz.zcu.yafmt.model.fm.Feature#getParentFeature
-     * @model opposite="parentFeature" containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Features</em>' containment reference list.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Features()
+	 * @see cz.zcu.yafmt.model.fm.Feature#getParentFeature
+	 * @model opposite="parentFeature" containment="true"
+	 * @generated
+	 */
     EList<Feature> getFeatures();
 
     /**
-     * Returns the value of the '<em><b>Groups</b></em>' containment reference list.
-     * The list contents are of type {@link cz.zcu.yafmt.model.fm.Group}.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Group#getParent <em>Parent</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Groups</b></em>' containment reference list.
+	 * The list contents are of type {@link cz.zcu.yafmt.model.fm.Group}.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Group#getParent <em>Parent</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Groups</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Groups</em>' containment reference list.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Groups()
-     * @see cz.zcu.yafmt.model.fm.Group#getParent
-     * @model opposite="parent" containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Groups</em>' containment reference list.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_Groups()
+	 * @see cz.zcu.yafmt.model.fm.Group#getParent
+	 * @model opposite="parent" containment="true"
+	 * @generated
+	 */
     EList<Group> getGroups();
 
     /**
-     * Returns the value of the '<em><b>Feature Model</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Feature Model</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Feature Model</em>' reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Feature Model</em>' reference.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_FeatureModel()
-     * @model transient="true" changeable="false" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Feature Model</em>' reference.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeature_FeatureModel()
+	 * @model transient="true" changeable="false" derived="true"
+	 * @generated
+	 */
     FeatureModel getFeatureModel();
 
 } // Feature

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/FeatureModel.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/FeatureModel.java
@@ -13,6 +13,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.FeatureModel#getName <em>Name</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.FeatureModel#getVersion <em>Version</em>}</li>
@@ -22,7 +23,6 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link cz.zcu.yafmt.model.fm.FeatureModel#getOrphans <em>Orphans</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.FeatureModel#getConstraints <em>Constraints</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel()
  * @model
@@ -30,173 +30,173 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface FeatureModel extends EObject {
     /**
-     * Returns the value of the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Name</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Name</em>' attribute.
-     * @see #setName(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Name()
-     * @model required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Name</em>' attribute.
+	 * @see #setName(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Name()
+	 * @model required="true"
+	 * @generated
+	 */
     String getName();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getName <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getName <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Name</em>' attribute.
-     * @see #getName()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Name</em>' attribute.
+	 * @see #getName()
+	 * @generated
+	 */
     void setName(String value);
 
     /**
-     * Returns the value of the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Description</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Description</em>' attribute.
-     * @see #setDescription(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Description()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Description</em>' attribute.
+	 * @see #setDescription(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Description()
+	 * @model
+	 * @generated
+	 */
     String getDescription();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getDescription <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getDescription <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Description</em>' attribute.
-     * @see #getDescription()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Description</em>' attribute.
+	 * @see #getDescription()
+	 * @generated
+	 */
     void setDescription(String value);
 
     /**
-     * Returns the value of the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Comment</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Comment</em>' attribute.
-     * @see #setComment(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Comment()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Comment</em>' attribute.
+	 * @see #setComment(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Comment()
+	 * @model
+	 * @generated
+	 */
     String getComment();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getComment <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getComment <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Comment</em>' attribute.
-     * @see #getComment()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Comment</em>' attribute.
+	 * @see #getComment()
+	 * @generated
+	 */
     void setComment(String value);
 
     /**
-     * Returns the value of the '<em><b>Version</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Version</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Version</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Version</em>' attribute.
-     * @see #setVersion(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Version()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Version</em>' attribute.
+	 * @see #setVersion(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Version()
+	 * @model
+	 * @generated
+	 */
     String getVersion();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getVersion <em>Version</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getVersion <em>Version</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Version</em>' attribute.
-     * @see #getVersion()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Version</em>' attribute.
+	 * @see #getVersion()
+	 * @generated
+	 */
     void setVersion(String value);
 
     /**
-     * Returns the value of the '<em><b>Root</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Root</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Root</em>' containment reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Root</em>' containment reference.
-     * @see #setRoot(Feature)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Root()
-     * @model containment="true" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Root</em>' containment reference.
+	 * @see #setRoot(Feature)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Root()
+	 * @model containment="true" required="true"
+	 * @generated
+	 */
     Feature getRoot();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getRoot <em>Root</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.FeatureModel#getRoot <em>Root</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Root</em>' containment reference.
-     * @see #getRoot()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Root</em>' containment reference.
+	 * @see #getRoot()
+	 * @generated
+	 */
     void setRoot(Feature value);
 
     /**
-     * Returns the value of the '<em><b>Orphans</b></em>' containment reference list.
-     * The list contents are of type {@link cz.zcu.yafmt.model.fm.Feature}.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Orphans</b></em>' containment reference list.
+	 * The list contents are of type {@link cz.zcu.yafmt.model.fm.Feature}.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Orphans</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Orphans</em>' containment reference list.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Orphans()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Orphans</em>' containment reference list.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Orphans()
+	 * @model containment="true"
+	 * @generated
+	 */
     EList<Feature> getOrphans();
 
     /**
-     * Returns the value of the '<em><b>Constraints</b></em>' containment reference list.
-     * The list contents are of type {@link cz.zcu.yafmt.model.fm.Constraint}.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Constraints</b></em>' containment reference list.
+	 * The list contents are of type {@link cz.zcu.yafmt.model.fm.Constraint}.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Constraints</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Constraints</em>' containment reference list.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Constraints()
-     * @model containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Constraints</em>' containment reference list.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getFeatureModel_Constraints()
+	 * @model containment="true"
+	 * @generated
+	 */
     EList<Constraint> getConstraints();
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @model many="false"
-     * @generated
-     */
+	 * @model many="false"
+	 * @generated
+	 */
     EList<Feature> getFeaturesById(String id);
 
 } // FeatureModel

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/FeatureModelFactory.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/FeatureModelFactory.java
@@ -14,65 +14,65 @@ import org.eclipse.emf.ecore.EFactory;
  */
 public interface FeatureModelFactory extends EFactory {
     /**
-     * The singleton instance of the factory.
-     * <!-- begin-user-doc -->
+	 * The singleton instance of the factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     FeatureModelFactory eINSTANCE = cz.zcu.yafmt.model.fm.impl.FeatureModelFactoryImpl.init();
 
     /**
-     * Returns a new object of class '<em>Feature Model</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Feature Model</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Feature Model</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Feature Model</em>'.
+	 * @generated
+	 */
     FeatureModel createFeatureModel();
 
     /**
-     * Returns a new object of class '<em>Feature</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Feature</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Feature</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Feature</em>'.
+	 * @generated
+	 */
     Feature createFeature();
 
     /**
-     * Returns a new object of class '<em>Group</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Group</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Group</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Group</em>'.
+	 * @generated
+	 */
     Group createGroup();
 
     /**
-     * Returns a new object of class '<em>Attribute</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Attribute</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Attribute</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Attribute</em>'.
+	 * @generated
+	 */
     Attribute createAttribute();
 
     /**
-     * Returns a new object of class '<em>Constraint</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Constraint</em>'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return a new object of class '<em>Constraint</em>'.
-     * @generated
-     */
+	 * @return a new object of class '<em>Constraint</em>'.
+	 * @generated
+	 */
     Constraint createConstraint();
 
     /**
-     * Returns the package supported by this factory.
-     * <!-- begin-user-doc -->
+	 * Returns the package supported by this factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the package supported by this factory.
-     * @generated
-     */
+	 * @return the package supported by this factory.
+	 * @generated
+	 */
     FeatureModelPackage getFeatureModelPackage();
 
 } //FeatureModelFactory

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/FeatureModelPackage.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/FeatureModelPackage.java
@@ -25,1094 +25,1114 @@ import org.eclipse.emf.ecore.EReference;
  */
 public interface FeatureModelPackage extends EPackage {
     /**
-     * The package name.
-     * <!-- begin-user-doc -->
+	 * The package name.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     String eNAME = "fm";
 
     /**
-     * The package namespace URI.
-     * <!-- begin-user-doc -->
+	 * The package namespace URI.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     String eNS_URI = "http://zcu.cz/yafmt/model/fm";
 
     /**
-     * The package namespace name.
-     * <!-- begin-user-doc -->
+	 * The package namespace name.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     String eNS_PREFIX = "fm";
 
     /**
-     * The singleton instance of the package.
-     * <!-- begin-user-doc -->
+	 * The singleton instance of the package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     FeatureModelPackage eINSTANCE = cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl.init();
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.FeatureModelImpl <em>Feature Model</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.FeatureModelImpl <em>Feature Model</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fm.impl.FeatureModelImpl
-     * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getFeatureModel()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelImpl
+	 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getFeatureModel()
+	 * @generated
+	 */
     int FEATURE_MODEL = 0;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_MODEL__NAME = 0;
 
     /**
-     * The feature id for the '<em><b>Version</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Version</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_MODEL__VERSION = 1;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_MODEL__DESCRIPTION = 2;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_MODEL__COMMENT = 3;
 
     /**
-     * The feature id for the '<em><b>Root</b></em>' containment reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Root</b></em>' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_MODEL__ROOT = 4;
 
     /**
-     * The feature id for the '<em><b>Orphans</b></em>' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Orphans</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_MODEL__ORPHANS = 5;
 
     /**
-     * The feature id for the '<em><b>Constraints</b></em>' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Constraints</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_MODEL__CONSTRAINTS = 6;
 
     /**
-     * The number of structural features of the '<em>Feature Model</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Feature Model</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_MODEL_FEATURE_COUNT = 7;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.FeatureImpl <em>Feature</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.FeatureImpl <em>Feature</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fm.impl.FeatureImpl
-     * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getFeature()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fm.impl.FeatureImpl
+	 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getFeature()
+	 * @generated
+	 */
     int FEATURE = 1;
 
     /**
-     * The feature id for the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__ID = 0;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__NAME = 1;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__DESCRIPTION = 2;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__COMMENT = 3;
 
     /**
-     * The feature id for the '<em><b>Lower</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Lower</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__LOWER = 4;
 
     /**
-     * The feature id for the '<em><b>Upper</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Upper</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__UPPER = 5;
 
     /**
-     * The feature id for the '<em><b>Root</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Root</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__ROOT = 6;
 
     /**
-     * The feature id for the '<em><b>Orphan</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Orphan</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__ORPHAN = 7;
 
     /**
-     * The feature id for the '<em><b>Optional</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Optional</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__OPTIONAL = 8;
 
     /**
-     * The feature id for the '<em><b>Mandatory</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Mandatory</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__MANDATORY = 9;
 
     /**
-     * The feature id for the '<em><b>Cloneable</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Cloneable</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__CLONEABLE = 10;
 
     /**
-     * The feature id for the '<em><b>Parent</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Parent</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__PARENT = 11;
 
     /**
-     * The feature id for the '<em><b>Parent Feature</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Parent Feature</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__PARENT_FEATURE = 12;
 
     /**
-     * The feature id for the '<em><b>Parent Group</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Parent Group</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__PARENT_GROUP = 13;
 
     /**
-     * The feature id for the '<em><b>Attributes</b></em>' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Attributes</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__ATTRIBUTES = 14;
 
     /**
-     * The feature id for the '<em><b>Features</b></em>' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Features</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__FEATURES = 15;
 
     /**
-     * The feature id for the '<em><b>Groups</b></em>' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Groups</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__GROUPS = 16;
 
     /**
-     * The feature id for the '<em><b>Feature Model</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Feature Model</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE__FEATURE_MODEL = 17;
 
     /**
-     * The number of structural features of the '<em>Feature</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Feature</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int FEATURE_FEATURE_COUNT = 18;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.GroupImpl <em>Group</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.GroupImpl <em>Group</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fm.impl.GroupImpl
-     * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getGroup()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fm.impl.GroupImpl
+	 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getGroup()
+	 * @generated
+	 */
     int GROUP = 2;
 
     /**
-     * The feature id for the '<em><b>Lower</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Lower</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int GROUP__LOWER = 0;
 
     /**
-     * The feature id for the '<em><b>Upper</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Upper</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int GROUP__UPPER = 1;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int GROUP__DESCRIPTION = 2;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int GROUP__COMMENT = 3;
 
     /**
-     * The feature id for the '<em><b>Xor</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Xor</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int GROUP__XOR = 4;
 
     /**
-     * The feature id for the '<em><b>Or</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Or</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int GROUP__OR = 5;
 
     /**
-     * The feature id for the '<em><b>Parent</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Parent</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int GROUP__PARENT = 6;
 
     /**
-     * The feature id for the '<em><b>Features</b></em>' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Features</b></em>' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int GROUP__FEATURES = 7;
 
     /**
-     * The number of structural features of the '<em>Group</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Group</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int GROUP_FEATURE_COUNT = 8;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl <em>Attribute</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl <em>Attribute</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fm.impl.AttributeImpl
-     * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getAttribute()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fm.impl.AttributeImpl
+	 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getAttribute()
+	 * @generated
+	 */
     int ATTRIBUTE = 3;
 
     /**
-     * The feature id for the '<em><b>Id</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE__ID = 0;
 
     /**
-     * The feature id for the '<em><b>Name</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE__NAME = 1;
 
     /**
-     * The feature id for the '<em><b>Type</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int ATTRIBUTE__TYPE = 2;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ATTRIBUTE__VALUE = 3;
+
+				/**
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
-    int ATTRIBUTE__DESCRIPTION = 3;
+	 * @generated
+	 * @ordered
+	 */
+    int ATTRIBUTE__DESCRIPTION = 4;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
-    int ATTRIBUTE__COMMENT = 4;
+	 * @generated
+	 * @ordered
+	 */
+    int ATTRIBUTE__COMMENT = 5;
 
     /**
-     * The feature id for the '<em><b>Feature</b></em>' container reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Feature</b></em>' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
-    int ATTRIBUTE__FEATURE = 5;
+	 * @generated
+	 * @ordered
+	 */
+    int ATTRIBUTE__FEATURE = 6;
 
     /**
-     * The number of structural features of the '<em>Attribute</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Attribute</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
-    int ATTRIBUTE_FEATURE_COUNT = 6;
+	 * @generated
+	 * @ordered
+	 */
+    int ATTRIBUTE_FEATURE_COUNT = 7;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.ConstraintImpl <em>Constraint</em>}' class.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fm.impl.ConstraintImpl <em>Constraint</em>}' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fm.impl.ConstraintImpl
-     * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getConstraint()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fm.impl.ConstraintImpl
+	 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getConstraint()
+	 * @generated
+	 */
     int CONSTRAINT = 4;
 
     /**
-     * The feature id for the '<em><b>Value</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Value</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int CONSTRAINT__VALUE = 0;
 
     /**
-     * The feature id for the '<em><b>Language</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Language</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int CONSTRAINT__LANGUAGE = 1;
 
     /**
-     * The feature id for the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int CONSTRAINT__DESCRIPTION = 2;
 
     /**
-     * The feature id for the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int CONSTRAINT__COMMENT = 3;
 
     /**
-     * The feature id for the '<em><b>Feature Model</b></em>' reference.
-     * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Feature Model</b></em>' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int CONSTRAINT__FEATURE_MODEL = 4;
 
     /**
-     * The number of structural features of the '<em>Constraint</em>' class.
-     * <!-- begin-user-doc -->
+	 * The number of structural features of the '<em>Constraint</em>' class.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     * @ordered
-     */
+	 * @generated
+	 * @ordered
+	 */
     int CONSTRAINT_FEATURE_COUNT = 5;
 
     /**
-     * The meta object id for the '{@link cz.zcu.yafmt.model.fm.AttributeType <em>Attribute Type</em>}' enum.
-     * <!-- begin-user-doc -->
+	 * The meta object id for the '{@link cz.zcu.yafmt.model.fm.AttributeType <em>Attribute Type</em>}' enum.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see cz.zcu.yafmt.model.fm.AttributeType
-     * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getAttributeType()
-     * @generated
-     */
+	 * @see cz.zcu.yafmt.model.fm.AttributeType
+	 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getAttributeType()
+	 * @generated
+	 */
     int ATTRIBUTE_TYPE = 5;
 
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.FeatureModel <em>Feature Model</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.FeatureModel <em>Feature Model</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Feature Model</em>'.
-     * @see cz.zcu.yafmt.model.fm.FeatureModel
-     * @generated
-     */
+	 * @return the meta object for class '<em>Feature Model</em>'.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModel
+	 * @generated
+	 */
     EClass getFeatureModel();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.FeatureModel#getName <em>Name</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.FeatureModel#getName <em>Name</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Name</em>'.
-     * @see cz.zcu.yafmt.model.fm.FeatureModel#getName()
-     * @see #getFeatureModel()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Name</em>'.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModel#getName()
+	 * @see #getFeatureModel()
+	 * @generated
+	 */
     EAttribute getFeatureModel_Name();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.FeatureModel#getDescription <em>Description</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.FeatureModel#getDescription <em>Description</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Description</em>'.
-     * @see cz.zcu.yafmt.model.fm.FeatureModel#getDescription()
-     * @see #getFeatureModel()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Description</em>'.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModel#getDescription()
+	 * @see #getFeatureModel()
+	 * @generated
+	 */
     EAttribute getFeatureModel_Description();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.FeatureModel#getComment <em>Comment</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.FeatureModel#getComment <em>Comment</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Comment</em>'.
-     * @see cz.zcu.yafmt.model.fm.FeatureModel#getComment()
-     * @see #getFeatureModel()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Comment</em>'.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModel#getComment()
+	 * @see #getFeatureModel()
+	 * @generated
+	 */
     EAttribute getFeatureModel_Comment();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.FeatureModel#getVersion <em>Version</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.FeatureModel#getVersion <em>Version</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Version</em>'.
-     * @see cz.zcu.yafmt.model.fm.FeatureModel#getVersion()
-     * @see #getFeatureModel()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Version</em>'.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModel#getVersion()
+	 * @see #getFeatureModel()
+	 * @generated
+	 */
     EAttribute getFeatureModel_Version();
 
     /**
-     * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.model.fm.FeatureModel#getRoot <em>Root</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference '{@link cz.zcu.yafmt.model.fm.FeatureModel#getRoot <em>Root</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference '<em>Root</em>'.
-     * @see cz.zcu.yafmt.model.fm.FeatureModel#getRoot()
-     * @see #getFeatureModel()
-     * @generated
-     */
+	 * @return the meta object for the containment reference '<em>Root</em>'.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModel#getRoot()
+	 * @see #getFeatureModel()
+	 * @generated
+	 */
     EReference getFeatureModel_Root();
 
     /**
-     * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.FeatureModel#getOrphans <em>Orphans</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.FeatureModel#getOrphans <em>Orphans</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference list '<em>Orphans</em>'.
-     * @see cz.zcu.yafmt.model.fm.FeatureModel#getOrphans()
-     * @see #getFeatureModel()
-     * @generated
-     */
+	 * @return the meta object for the containment reference list '<em>Orphans</em>'.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModel#getOrphans()
+	 * @see #getFeatureModel()
+	 * @generated
+	 */
     EReference getFeatureModel_Orphans();
 
     /**
-     * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.FeatureModel#getConstraints <em>Constraints</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.FeatureModel#getConstraints <em>Constraints</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference list '<em>Constraints</em>'.
-     * @see cz.zcu.yafmt.model.fm.FeatureModel#getConstraints()
-     * @see #getFeatureModel()
-     * @generated
-     */
+	 * @return the meta object for the containment reference list '<em>Constraints</em>'.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModel#getConstraints()
+	 * @see #getFeatureModel()
+	 * @generated
+	 */
     EReference getFeatureModel_Constraints();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.Feature <em>Feature</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.Feature <em>Feature</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Feature</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature
-     * @generated
-     */
+	 * @return the meta object for class '<em>Feature</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature
+	 * @generated
+	 */
     EClass getFeature();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getId <em>Id</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getId <em>Id</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Id</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getId()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Id</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getId()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Id();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getName <em>Name</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getName <em>Name</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Name</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getName()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Name</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getName()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Name();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getDescription <em>Description</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getDescription <em>Description</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Description</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getDescription()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Description</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getDescription()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Description();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getComment <em>Comment</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getComment <em>Comment</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Comment</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getComment()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Comment</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getComment()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Comment();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getLower <em>Lower</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getLower <em>Lower</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Lower</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getLower()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Lower</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getLower()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Lower();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getUpper <em>Upper</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#getUpper <em>Upper</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Upper</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getUpper()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Upper</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getUpper()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Upper();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isRoot <em>Root</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isRoot <em>Root</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Root</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#isRoot()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Root</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#isRoot()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Root();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isOrphan <em>Orphan</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isOrphan <em>Orphan</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Orphan</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#isOrphan()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Orphan</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#isOrphan()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Orphan();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isOptional <em>Optional</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isOptional <em>Optional</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Optional</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#isOptional()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Optional</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#isOptional()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Optional();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isMandatory <em>Mandatory</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isMandatory <em>Mandatory</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Mandatory</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#isMandatory()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Mandatory</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#isMandatory()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Mandatory();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isCloneable <em>Cloneable</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Feature#isCloneable <em>Cloneable</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Cloneable</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#isCloneable()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Cloneable</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#isCloneable()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EAttribute getFeature_Cloneable();
 
     /**
-     * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.Feature#getAttributes <em>Attributes</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.Feature#getAttributes <em>Attributes</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference list '<em>Attributes</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getAttributes()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the containment reference list '<em>Attributes</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getAttributes()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EReference getFeature_Attributes();
 
     /**
-     * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fm.Feature#getParent <em>Parent</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fm.Feature#getParent <em>Parent</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the reference '<em>Parent</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getParent()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the reference '<em>Parent</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getParent()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EReference getFeature_Parent();
 
     /**
-     * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fm.Feature#getParentFeature <em>Parent Feature</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fm.Feature#getParentFeature <em>Parent Feature</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the container reference '<em>Parent Feature</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getParentFeature()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the container reference '<em>Parent Feature</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getParentFeature()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EReference getFeature_ParentFeature();
 
     /**
-     * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fm.Feature#getParentGroup <em>Parent Group</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fm.Feature#getParentGroup <em>Parent Group</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the container reference '<em>Parent Group</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getParentGroup()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the container reference '<em>Parent Group</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getParentGroup()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EReference getFeature_ParentGroup();
 
     /**
-     * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.Feature#getFeatures <em>Features</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.Feature#getFeatures <em>Features</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference list '<em>Features</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getFeatures()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the containment reference list '<em>Features</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getFeatures()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EReference getFeature_Features();
 
     /**
-     * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.Feature#getGroups <em>Groups</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.Feature#getGroups <em>Groups</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference list '<em>Groups</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getGroups()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the containment reference list '<em>Groups</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getGroups()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EReference getFeature_Groups();
 
     /**
-     * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fm.Feature#getFeatureModel <em>Feature Model</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fm.Feature#getFeatureModel <em>Feature Model</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the reference '<em>Feature Model</em>'.
-     * @see cz.zcu.yafmt.model.fm.Feature#getFeatureModel()
-     * @see #getFeature()
-     * @generated
-     */
+	 * @return the meta object for the reference '<em>Feature Model</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Feature#getFeatureModel()
+	 * @see #getFeature()
+	 * @generated
+	 */
     EReference getFeature_FeatureModel();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.Group <em>Group</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.Group <em>Group</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Group</em>'.
-     * @see cz.zcu.yafmt.model.fm.Group
-     * @generated
-     */
+	 * @return the meta object for class '<em>Group</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Group
+	 * @generated
+	 */
     EClass getGroup();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#getLower <em>Lower</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#getLower <em>Lower</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Lower</em>'.
-     * @see cz.zcu.yafmt.model.fm.Group#getLower()
-     * @see #getGroup()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Lower</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Group#getLower()
+	 * @see #getGroup()
+	 * @generated
+	 */
     EAttribute getGroup_Lower();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#getUpper <em>Upper</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#getUpper <em>Upper</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Upper</em>'.
-     * @see cz.zcu.yafmt.model.fm.Group#getUpper()
-     * @see #getGroup()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Upper</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Group#getUpper()
+	 * @see #getGroup()
+	 * @generated
+	 */
     EAttribute getGroup_Upper();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#getDescription <em>Description</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#getDescription <em>Description</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Description</em>'.
-     * @see cz.zcu.yafmt.model.fm.Group#getDescription()
-     * @see #getGroup()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Description</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Group#getDescription()
+	 * @see #getGroup()
+	 * @generated
+	 */
     EAttribute getGroup_Description();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#getComment <em>Comment</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#getComment <em>Comment</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Comment</em>'.
-     * @see cz.zcu.yafmt.model.fm.Group#getComment()
-     * @see #getGroup()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Comment</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Group#getComment()
+	 * @see #getGroup()
+	 * @generated
+	 */
     EAttribute getGroup_Comment();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#isXor <em>Xor</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#isXor <em>Xor</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Xor</em>'.
-     * @see cz.zcu.yafmt.model.fm.Group#isXor()
-     * @see #getGroup()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Xor</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Group#isXor()
+	 * @see #getGroup()
+	 * @generated
+	 */
     EAttribute getGroup_Xor();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#isOr <em>Or</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Group#isOr <em>Or</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Or</em>'.
-     * @see cz.zcu.yafmt.model.fm.Group#isOr()
-     * @see #getGroup()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Or</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Group#isOr()
+	 * @see #getGroup()
+	 * @generated
+	 */
     EAttribute getGroup_Or();
 
     /**
-     * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fm.Group#getParent <em>Parent</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fm.Group#getParent <em>Parent</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the container reference '<em>Parent</em>'.
-     * @see cz.zcu.yafmt.model.fm.Group#getParent()
-     * @see #getGroup()
-     * @generated
-     */
+	 * @return the meta object for the container reference '<em>Parent</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Group#getParent()
+	 * @see #getGroup()
+	 * @generated
+	 */
     EReference getGroup_Parent();
 
     /**
-     * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.Group#getFeatures <em>Features</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the containment reference list '{@link cz.zcu.yafmt.model.fm.Group#getFeatures <em>Features</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the containment reference list '<em>Features</em>'.
-     * @see cz.zcu.yafmt.model.fm.Group#getFeatures()
-     * @see #getGroup()
-     * @generated
-     */
+	 * @return the meta object for the containment reference list '<em>Features</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Group#getFeatures()
+	 * @see #getGroup()
+	 * @generated
+	 */
     EReference getGroup_Features();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.Attribute <em>Attribute</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.Attribute <em>Attribute</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Attribute</em>'.
-     * @see cz.zcu.yafmt.model.fm.Attribute
-     * @generated
-     */
+	 * @return the meta object for class '<em>Attribute</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Attribute
+	 * @generated
+	 */
     EClass getAttribute();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getId <em>Id</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getId <em>Id</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Id</em>'.
-     * @see cz.zcu.yafmt.model.fm.Attribute#getId()
-     * @see #getAttribute()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Id</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Attribute#getId()
+	 * @see #getAttribute()
+	 * @generated
+	 */
     EAttribute getAttribute_Id();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getName <em>Name</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getName <em>Name</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Name</em>'.
-     * @see cz.zcu.yafmt.model.fm.Attribute#getName()
-     * @see #getAttribute()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Name</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Attribute#getName()
+	 * @see #getAttribute()
+	 * @generated
+	 */
     EAttribute getAttribute_Name();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getDescription <em>Description</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getDescription <em>Description</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Description</em>'.
-     * @see cz.zcu.yafmt.model.fm.Attribute#getDescription()
-     * @see #getAttribute()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Description</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Attribute#getDescription()
+	 * @see #getAttribute()
+	 * @generated
+	 */
     EAttribute getAttribute_Description();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getComment <em>Comment</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getComment <em>Comment</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Comment</em>'.
-     * @see cz.zcu.yafmt.model.fm.Attribute#getComment()
-     * @see #getAttribute()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Comment</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Attribute#getComment()
+	 * @see #getAttribute()
+	 * @generated
+	 */
     EAttribute getAttribute_Comment();
 
     /**
-     * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fm.Attribute#getFeature <em>Feature</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the container reference '{@link cz.zcu.yafmt.model.fm.Attribute#getFeature <em>Feature</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the container reference '<em>Feature</em>'.
-     * @see cz.zcu.yafmt.model.fm.Attribute#getFeature()
-     * @see #getAttribute()
-     * @generated
-     */
+	 * @return the meta object for the container reference '<em>Feature</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Attribute#getFeature()
+	 * @see #getAttribute()
+	 * @generated
+	 */
     EReference getAttribute_Feature();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getType <em>Type</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getType <em>Type</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Type</em>'.
-     * @see cz.zcu.yafmt.model.fm.Attribute#getType()
-     * @see #getAttribute()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Type</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Attribute#getType()
+	 * @see #getAttribute()
+	 * @generated
+	 */
     EAttribute getAttribute_Type();
 
     /**
-     * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.Constraint <em>Constraint</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Attribute#getValue <em>Value</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Value</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Attribute#getValue()
+	 * @see #getAttribute()
+	 * @generated
+	 */
+	EAttribute getAttribute_Value();
+
+				/**
+	 * Returns the meta object for class '{@link cz.zcu.yafmt.model.fm.Constraint <em>Constraint</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for class '<em>Constraint</em>'.
-     * @see cz.zcu.yafmt.model.fm.Constraint
-     * @generated
-     */
+	 * @return the meta object for class '<em>Constraint</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Constraint
+	 * @generated
+	 */
     EClass getConstraint();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Constraint#getValue <em>Value</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Constraint#getValue <em>Value</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Value</em>'.
-     * @see cz.zcu.yafmt.model.fm.Constraint#getValue()
-     * @see #getConstraint()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Value</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Constraint#getValue()
+	 * @see #getConstraint()
+	 * @generated
+	 */
     EAttribute getConstraint_Value();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Constraint#getLanguage <em>Language</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Constraint#getLanguage <em>Language</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Language</em>'.
-     * @see cz.zcu.yafmt.model.fm.Constraint#getLanguage()
-     * @see #getConstraint()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Language</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Constraint#getLanguage()
+	 * @see #getConstraint()
+	 * @generated
+	 */
     EAttribute getConstraint_Language();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Constraint#getDescription <em>Description</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Constraint#getDescription <em>Description</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Description</em>'.
-     * @see cz.zcu.yafmt.model.fm.Constraint#getDescription()
-     * @see #getConstraint()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Description</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Constraint#getDescription()
+	 * @see #getConstraint()
+	 * @generated
+	 */
     EAttribute getConstraint_Description();
 
     /**
-     * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Constraint#getComment <em>Comment</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the attribute '{@link cz.zcu.yafmt.model.fm.Constraint#getComment <em>Comment</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the attribute '<em>Comment</em>'.
-     * @see cz.zcu.yafmt.model.fm.Constraint#getComment()
-     * @see #getConstraint()
-     * @generated
-     */
+	 * @return the meta object for the attribute '<em>Comment</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Constraint#getComment()
+	 * @see #getConstraint()
+	 * @generated
+	 */
     EAttribute getConstraint_Comment();
 
     /**
-     * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fm.Constraint#getFeatureModel <em>Feature Model</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for the reference '{@link cz.zcu.yafmt.model.fm.Constraint#getFeatureModel <em>Feature Model</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for the reference '<em>Feature Model</em>'.
-     * @see cz.zcu.yafmt.model.fm.Constraint#getFeatureModel()
-     * @see #getConstraint()
-     * @generated
-     */
+	 * @return the meta object for the reference '<em>Feature Model</em>'.
+	 * @see cz.zcu.yafmt.model.fm.Constraint#getFeatureModel()
+	 * @see #getConstraint()
+	 * @generated
+	 */
     EReference getConstraint_FeatureModel();
 
     /**
-     * Returns the meta object for enum '{@link cz.zcu.yafmt.model.fm.AttributeType <em>Attribute Type</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the meta object for enum '{@link cz.zcu.yafmt.model.fm.AttributeType <em>Attribute Type</em>}'.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the meta object for enum '<em>Attribute Type</em>'.
-     * @see cz.zcu.yafmt.model.fm.AttributeType
-     * @generated
-     */
+	 * @return the meta object for enum '<em>Attribute Type</em>'.
+	 * @see cz.zcu.yafmt.model.fm.AttributeType
+	 * @generated
+	 */
     EEnum getAttributeType();
 
     /**
-     * Returns the factory that creates the instances of the model.
-     * <!-- begin-user-doc -->
+	 * Returns the factory that creates the instances of the model.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the factory that creates the instances of the model.
-     * @generated
-     */
+	 * @return the factory that creates the instances of the model.
+	 * @generated
+	 */
     FeatureModelFactory getFeatureModelFactory();
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * Defines literals for the meta objects that represent
      * <ul>
      *   <li>each class,</li>
@@ -1121,419 +1141,427 @@ public interface FeatureModelPackage extends EPackage {
      *   <li>and each data type</li>
      * </ul>
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     interface Literals {
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.FeatureModelImpl <em>Feature Model</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.FeatureModelImpl <em>Feature Model</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fm.impl.FeatureModelImpl
-         * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getFeatureModel()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelImpl
+		 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getFeatureModel()
+		 * @generated
+		 */
         EClass FEATURE_MODEL = eINSTANCE.getFeatureModel();
 
         /**
-         * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE_MODEL__NAME = eINSTANCE.getFeatureModel_Name();
 
         /**
-         * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE_MODEL__DESCRIPTION = eINSTANCE.getFeatureModel_Description();
 
         /**
-         * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE_MODEL__COMMENT = eINSTANCE.getFeatureModel_Comment();
 
         /**
-         * The meta object literal for the '<em><b>Version</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Version</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE_MODEL__VERSION = eINSTANCE.getFeatureModel_Version();
 
         /**
-         * The meta object literal for the '<em><b>Root</b></em>' containment reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Root</b></em>' containment reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE_MODEL__ROOT = eINSTANCE.getFeatureModel_Root();
 
         /**
-         * The meta object literal for the '<em><b>Orphans</b></em>' containment reference list feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Orphans</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE_MODEL__ORPHANS = eINSTANCE.getFeatureModel_Orphans();
 
         /**
-         * The meta object literal for the '<em><b>Constraints</b></em>' containment reference list feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Constraints</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE_MODEL__CONSTRAINTS = eINSTANCE.getFeatureModel_Constraints();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.FeatureImpl <em>Feature</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.FeatureImpl <em>Feature</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fm.impl.FeatureImpl
-         * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getFeature()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fm.impl.FeatureImpl
+		 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getFeature()
+		 * @generated
+		 */
         EClass FEATURE = eINSTANCE.getFeature();
 
         /**
-         * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__ID = eINSTANCE.getFeature_Id();
 
         /**
-         * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__NAME = eINSTANCE.getFeature_Name();
 
         /**
-         * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__DESCRIPTION = eINSTANCE.getFeature_Description();
 
         /**
-         * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__COMMENT = eINSTANCE.getFeature_Comment();
 
         /**
-         * The meta object literal for the '<em><b>Lower</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Lower</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__LOWER = eINSTANCE.getFeature_Lower();
 
         /**
-         * The meta object literal for the '<em><b>Upper</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Upper</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__UPPER = eINSTANCE.getFeature_Upper();
 
         /**
-         * The meta object literal for the '<em><b>Root</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Root</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__ROOT = eINSTANCE.getFeature_Root();
 
         /**
-         * The meta object literal for the '<em><b>Orphan</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Orphan</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__ORPHAN = eINSTANCE.getFeature_Orphan();
 
         /**
-         * The meta object literal for the '<em><b>Optional</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Optional</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__OPTIONAL = eINSTANCE.getFeature_Optional();
 
         /**
-         * The meta object literal for the '<em><b>Mandatory</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Mandatory</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__MANDATORY = eINSTANCE.getFeature_Mandatory();
 
         /**
-         * The meta object literal for the '<em><b>Cloneable</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Cloneable</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute FEATURE__CLONEABLE = eINSTANCE.getFeature_Cloneable();
 
         /**
-         * The meta object literal for the '<em><b>Attributes</b></em>' containment reference list feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Attributes</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE__ATTRIBUTES = eINSTANCE.getFeature_Attributes();
 
         /**
-         * The meta object literal for the '<em><b>Parent</b></em>' reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Parent</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE__PARENT = eINSTANCE.getFeature_Parent();
 
         /**
-         * The meta object literal for the '<em><b>Parent Feature</b></em>' container reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Parent Feature</b></em>' container reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE__PARENT_FEATURE = eINSTANCE.getFeature_ParentFeature();
 
         /**
-         * The meta object literal for the '<em><b>Parent Group</b></em>' container reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Parent Group</b></em>' container reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE__PARENT_GROUP = eINSTANCE.getFeature_ParentGroup();
 
         /**
-         * The meta object literal for the '<em><b>Features</b></em>' containment reference list feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Features</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE__FEATURES = eINSTANCE.getFeature_Features();
 
         /**
-         * The meta object literal for the '<em><b>Groups</b></em>' containment reference list feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Groups</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE__GROUPS = eINSTANCE.getFeature_Groups();
 
         /**
-         * The meta object literal for the '<em><b>Feature Model</b></em>' reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Feature Model</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference FEATURE__FEATURE_MODEL = eINSTANCE.getFeature_FeatureModel();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.GroupImpl <em>Group</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.GroupImpl <em>Group</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fm.impl.GroupImpl
-         * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getGroup()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fm.impl.GroupImpl
+		 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getGroup()
+		 * @generated
+		 */
         EClass GROUP = eINSTANCE.getGroup();
 
         /**
-         * The meta object literal for the '<em><b>Lower</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Lower</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute GROUP__LOWER = eINSTANCE.getGroup_Lower();
 
         /**
-         * The meta object literal for the '<em><b>Upper</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Upper</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute GROUP__UPPER = eINSTANCE.getGroup_Upper();
 
         /**
-         * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute GROUP__DESCRIPTION = eINSTANCE.getGroup_Description();
 
         /**
-         * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute GROUP__COMMENT = eINSTANCE.getGroup_Comment();
 
         /**
-         * The meta object literal for the '<em><b>Xor</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Xor</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute GROUP__XOR = eINSTANCE.getGroup_Xor();
 
         /**
-         * The meta object literal for the '<em><b>Or</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Or</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute GROUP__OR = eINSTANCE.getGroup_Or();
 
         /**
-         * The meta object literal for the '<em><b>Parent</b></em>' container reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Parent</b></em>' container reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference GROUP__PARENT = eINSTANCE.getGroup_Parent();
 
         /**
-         * The meta object literal for the '<em><b>Features</b></em>' containment reference list feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Features</b></em>' containment reference list feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference GROUP__FEATURES = eINSTANCE.getGroup_Features();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl <em>Attribute</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl <em>Attribute</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fm.impl.AttributeImpl
-         * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getAttribute()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fm.impl.AttributeImpl
+		 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getAttribute()
+		 * @generated
+		 */
         EClass ATTRIBUTE = eINSTANCE.getAttribute();
 
         /**
-         * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute ATTRIBUTE__ID = eINSTANCE.getAttribute_Id();
 
         /**
-         * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute ATTRIBUTE__NAME = eINSTANCE.getAttribute_Name();
 
         /**
-         * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute ATTRIBUTE__DESCRIPTION = eINSTANCE.getAttribute_Description();
 
         /**
-         * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute ATTRIBUTE__COMMENT = eINSTANCE.getAttribute_Comment();
 
         /**
-         * The meta object literal for the '<em><b>Feature</b></em>' container reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Feature</b></em>' container reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference ATTRIBUTE__FEATURE = eINSTANCE.getAttribute_Feature();
 
         /**
-         * The meta object literal for the '<em><b>Type</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Type</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute ATTRIBUTE__TYPE = eINSTANCE.getAttribute_Type();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.ConstraintImpl <em>Constraint</em>}' class.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute ATTRIBUTE__VALUE = eINSTANCE.getAttribute_Value();
+
+								/**
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.impl.ConstraintImpl <em>Constraint</em>}' class.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fm.impl.ConstraintImpl
-         * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getConstraint()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fm.impl.ConstraintImpl
+		 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getConstraint()
+		 * @generated
+		 */
         EClass CONSTRAINT = eINSTANCE.getConstraint();
 
         /**
-         * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute CONSTRAINT__VALUE = eINSTANCE.getConstraint_Value();
 
         /**
-         * The meta object literal for the '<em><b>Language</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Language</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute CONSTRAINT__LANGUAGE = eINSTANCE.getConstraint_Language();
 
         /**
-         * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Description</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute CONSTRAINT__DESCRIPTION = eINSTANCE.getConstraint_Description();
 
         /**
-         * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Comment</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EAttribute CONSTRAINT__COMMENT = eINSTANCE.getConstraint_Comment();
 
         /**
-         * The meta object literal for the '<em><b>Feature Model</b></em>' reference feature.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '<em><b>Feature Model</b></em>' reference feature.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @generated
-         */
+		 * @generated
+		 */
         EReference CONSTRAINT__FEATURE_MODEL = eINSTANCE.getConstraint_FeatureModel();
 
         /**
-         * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.AttributeType <em>Attribute Type</em>}' enum.
-         * <!-- begin-user-doc -->
+		 * The meta object literal for the '{@link cz.zcu.yafmt.model.fm.AttributeType <em>Attribute Type</em>}' enum.
+		 * <!-- begin-user-doc -->
          * <!-- end-user-doc -->
-         * @see cz.zcu.yafmt.model.fm.AttributeType
-         * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getAttributeType()
-         * @generated
-         */
+		 * @see cz.zcu.yafmt.model.fm.AttributeType
+		 * @see cz.zcu.yafmt.model.fm.impl.FeatureModelPackageImpl#getAttributeType()
+		 * @generated
+		 */
         EEnum ATTRIBUTE_TYPE = eINSTANCE.getAttributeType();
 
     }

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/Group.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/Group.java
@@ -13,6 +13,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * <p>
  * The following features are supported:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.Group#getLower <em>Lower</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Group#getUpper <em>Upper</em>}</li>
@@ -23,7 +24,6 @@ import org.eclipse.emf.ecore.EObject;
  *   <li>{@link cz.zcu.yafmt.model.fm.Group#getParent <em>Parent</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.Group#getFeatures <em>Features</em>}</li>
  * </ul>
- * </p>
  *
  * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup()
  * @model
@@ -31,207 +31,207 @@ import org.eclipse.emf.ecore.EObject;
  */
 public interface Group extends EObject {
     /**
-     * Returns the value of the '<em><b>Lower</b></em>' attribute.
-     * The default value is <code>"1"</code>.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Lower</b></em>' attribute.
+	 * The default value is <code>"1"</code>.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Lower</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Lower</em>' attribute.
-     * @see #setLower(int)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Lower()
-     * @model default="1" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Lower</em>' attribute.
+	 * @see #setLower(int)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Lower()
+	 * @model default="1" required="true"
+	 * @generated
+	 */
     int getLower();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getLower <em>Lower</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getLower <em>Lower</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Lower</em>' attribute.
-     * @see #getLower()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Lower</em>' attribute.
+	 * @see #getLower()
+	 * @generated
+	 */
     void setLower(int value);
 
     /**
-     * Returns the value of the '<em><b>Upper</b></em>' attribute.
-     * The default value is <code>"1"</code>.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Upper</b></em>' attribute.
+	 * The default value is <code>"1"</code>.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Upper</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Upper</em>' attribute.
-     * @see #setUpper(int)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Upper()
-     * @model default="1" required="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Upper</em>' attribute.
+	 * @see #setUpper(int)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Upper()
+	 * @model default="1" required="true"
+	 * @generated
+	 */
     int getUpper();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getUpper <em>Upper</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getUpper <em>Upper</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Upper</em>' attribute.
-     * @see #getUpper()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Upper</em>' attribute.
+	 * @see #getUpper()
+	 * @generated
+	 */
     void setUpper(int value);
 
     /**
-     * Returns the value of the '<em><b>Description</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Description</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Description</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Description</em>' attribute.
-     * @see #setDescription(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Description()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Description</em>' attribute.
+	 * @see #setDescription(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Description()
+	 * @model
+	 * @generated
+	 */
     String getDescription();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getDescription <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getDescription <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Description</em>' attribute.
-     * @see #getDescription()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Description</em>' attribute.
+	 * @see #getDescription()
+	 * @generated
+	 */
     void setDescription(String value);
 
     /**
-     * Returns the value of the '<em><b>Comment</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Comment</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Comment</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Comment</em>' attribute.
-     * @see #setComment(String)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Comment()
-     * @model
-     * @generated
-     */
+	 * @return the value of the '<em>Comment</em>' attribute.
+	 * @see #setComment(String)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Comment()
+	 * @model
+	 * @generated
+	 */
     String getComment();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getComment <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getComment <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Comment</em>' attribute.
-     * @see #getComment()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Comment</em>' attribute.
+	 * @see #getComment()
+	 * @generated
+	 */
     void setComment(String value);
 
     /**
-     * Returns the value of the '<em><b>Xor</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Xor</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Xor</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Xor</em>' attribute.
-     * @see #setXor(boolean)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Xor()
-     * @model required="true" transient="true" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Xor</em>' attribute.
+	 * @see #setXor(boolean)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Xor()
+	 * @model required="true" transient="true" volatile="true" derived="true"
+	 * @generated
+	 */
     boolean isXor();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#isXor <em>Xor</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#isXor <em>Xor</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Xor</em>' attribute.
-     * @see #isXor()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Xor</em>' attribute.
+	 * @see #isXor()
+	 * @generated
+	 */
     void setXor(boolean value);
 
     /**
-     * Returns the value of the '<em><b>Or</b></em>' attribute.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Or</b></em>' attribute.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Or</em>' attribute isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Or</em>' attribute.
-     * @see #setOr(boolean)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Or()
-     * @model required="true" transient="true" volatile="true" derived="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Or</em>' attribute.
+	 * @see #setOr(boolean)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Or()
+	 * @model required="true" transient="true" volatile="true" derived="true"
+	 * @generated
+	 */
     boolean isOr();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#isOr <em>Or</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#isOr <em>Or</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Or</em>' attribute.
-     * @see #isOr()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Or</em>' attribute.
+	 * @see #isOr()
+	 * @generated
+	 */
     void setOr(boolean value);
 
     /**
-     * Returns the value of the '<em><b>Parent</b></em>' container reference.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getGroups <em>Groups</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Parent</b></em>' container reference.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getGroups <em>Groups</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Parent</em>' container reference isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Parent</em>' container reference.
-     * @see #setParent(Feature)
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Parent()
-     * @see cz.zcu.yafmt.model.fm.Feature#getGroups
-     * @model opposite="groups" required="true" transient="false"
-     * @generated
-     */
+	 * @return the value of the '<em>Parent</em>' container reference.
+	 * @see #setParent(Feature)
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Parent()
+	 * @see cz.zcu.yafmt.model.fm.Feature#getGroups
+	 * @model opposite="groups" required="true" transient="false"
+	 * @generated
+	 */
     Feature getParent();
 
     /**
-     * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getParent <em>Parent</em>}' container reference.
-     * <!-- begin-user-doc -->
+	 * Sets the value of the '{@link cz.zcu.yafmt.model.fm.Group#getParent <em>Parent</em>}' container reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @param value the new value of the '<em>Parent</em>' container reference.
-     * @see #getParent()
-     * @generated
-     */
+	 * @param value the new value of the '<em>Parent</em>' container reference.
+	 * @see #getParent()
+	 * @generated
+	 */
     void setParent(Feature value);
 
     /**
-     * Returns the value of the '<em><b>Features</b></em>' containment reference list.
-     * The list contents are of type {@link cz.zcu.yafmt.model.fm.Feature}.
-     * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getParentGroup <em>Parent Group</em>}'.
-     * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Features</b></em>' containment reference list.
+	 * The list contents are of type {@link cz.zcu.yafmt.model.fm.Feature}.
+	 * It is bidirectional and its opposite is '{@link cz.zcu.yafmt.model.fm.Feature#getParentGroup <em>Parent Group</em>}'.
+	 * <!-- begin-user-doc -->
      * <p>
      * If the meaning of the '<em>Features</em>' containment reference list isn't clear,
      * there really should be more of a description here...
      * </p>
      * <!-- end-user-doc -->
-     * @return the value of the '<em>Features</em>' containment reference list.
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Features()
-     * @see cz.zcu.yafmt.model.fm.Feature#getParentGroup
-     * @model opposite="parentGroup" containment="true"
-     * @generated
-     */
+	 * @return the value of the '<em>Features</em>' containment reference list.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#getGroup_Features()
+	 * @see cz.zcu.yafmt.model.fm.Feature#getParentGroup
+	 * @model opposite="parentGroup" containment="true"
+	 * @generated
+	 */
     EList<Feature> getFeatures();
 
 } // Group

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/AttributeImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/AttributeImpl.java
@@ -23,458 +23,512 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl#getId <em>Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl#getName <em>Name</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl#getType <em>Type</em>}</li>
+ *   <li>{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl#getValue <em>Value</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl#getDescription <em>Description</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl#getComment <em>Comment</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.AttributeImpl#getFeature <em>Feature</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class AttributeImpl extends EObjectImpl implements Attribute {
     /**
-     * The default value of the '{@link #getId() <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String ID_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
     protected String id = ID_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String NAME_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected String name = NAME_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getType() <em>Type</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getType() <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getType()
-     * @generated
-     * @ordered
-     */
+	 * @see #getType()
+	 * @generated
+	 * @ordered
+	 */
     protected static final AttributeType TYPE_EDEFAULT = AttributeType.BOOLEAN;
 
     /**
-     * The cached value of the '{@link #getType() <em>Type</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getType()
-     * @generated
-     * @ordered
-     */
+	 * @see #getType()
+	 * @generated
+	 * @ordered
+	 */
     protected AttributeType type = TYPE_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String VALUE_EDEFAULT = null;
+
+				/**
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
+	protected String value = VALUE_EDEFAULT;
+
+				/**
+	 * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String DESCRIPTION_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected String description = DESCRIPTION_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String COMMENT_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected String comment = COMMENT_EDEFAULT;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected AttributeImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureModelPackage.Literals.ATTRIBUTE;
-    }
+		return FeatureModelPackage.Literals.ATTRIBUTE;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getId() {
-        return id;
-    }
+		return id;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setId(String newId) {
-        String oldId = id;
-        id = newId;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__ID, oldId, id));
-    }
+		String oldId = id;
+		id = newId;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__ID, oldId, id));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getName() {
-        return name;
-    }
+		return name;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setName(String newName) {
-        String oldName = name;
-        name = newName;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__NAME, oldName, name));
-    }
+		String oldName = name;
+		name = newName;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__NAME, oldName, name));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getDescription() {
-        return description;
-    }
+		return description;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setDescription(String newDescription) {
-        String oldDescription = description;
-        description = newDescription;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__DESCRIPTION, oldDescription, description));
-    }
+		String oldDescription = description;
+		description = newDescription;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__DESCRIPTION, oldDescription, description));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getComment() {
-        return comment;
-    }
+		return comment;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setComment(String newComment) {
-        String oldComment = comment;
-        comment = newComment;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__COMMENT, oldComment, comment));
-    }
+		String oldComment = comment;
+		comment = newComment;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__COMMENT, oldComment, comment));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Feature getFeature() {
-        if (eContainerFeatureID() != FeatureModelPackage.ATTRIBUTE__FEATURE) return null;
-        return (Feature)eContainer();
-    }
+		if (eContainerFeatureID() != FeatureModelPackage.ATTRIBUTE__FEATURE) return null;
+		return (Feature)eInternalContainer();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetFeature(Feature newFeature, NotificationChain msgs) {
-        msgs = eBasicSetContainer((InternalEObject)newFeature, FeatureModelPackage.ATTRIBUTE__FEATURE, msgs);
-        return msgs;
-    }
+		msgs = eBasicSetContainer((InternalEObject)newFeature, FeatureModelPackage.ATTRIBUTE__FEATURE, msgs);
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setFeature(Feature newFeature) {
-        if (newFeature != eInternalContainer() || (eContainerFeatureID() != FeatureModelPackage.ATTRIBUTE__FEATURE && newFeature != null)) {
-            if (EcoreUtil.isAncestor(this, newFeature))
-                throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
-            NotificationChain msgs = null;
-            if (eInternalContainer() != null)
-                msgs = eBasicRemoveFromContainer(msgs);
-            if (newFeature != null)
-                msgs = ((InternalEObject)newFeature).eInverseAdd(this, FeatureModelPackage.FEATURE__ATTRIBUTES, Feature.class, msgs);
-            msgs = basicSetFeature(newFeature, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__FEATURE, newFeature, newFeature));
-    }
+		if (newFeature != eInternalContainer() || (eContainerFeatureID() != FeatureModelPackage.ATTRIBUTE__FEATURE && newFeature != null)) {
+			if (EcoreUtil.isAncestor(this, newFeature))
+				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
+			NotificationChain msgs = null;
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
+			if (newFeature != null)
+				msgs = ((InternalEObject)newFeature).eInverseAdd(this, FeatureModelPackage.FEATURE__ATTRIBUTES, Feature.class, msgs);
+			msgs = basicSetFeature(newFeature, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__FEATURE, newFeature, newFeature));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureModelPackage.ATTRIBUTE__FEATURE:
-                if (eInternalContainer() != null)
-                    msgs = eBasicRemoveFromContainer(msgs);
-                return basicSetFeature((Feature)otherEnd, msgs);
-        }
-        return super.eInverseAdd(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.ATTRIBUTE__FEATURE:
+				if (eInternalContainer() != null)
+					msgs = eBasicRemoveFromContainer(msgs);
+				return basicSetFeature((Feature)otherEnd, msgs);
+		}
+		return super.eInverseAdd(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureModelPackage.ATTRIBUTE__FEATURE:
-                return basicSetFeature(null, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.ATTRIBUTE__FEATURE:
+				return basicSetFeature(null, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eBasicRemoveFromContainerFeature(NotificationChain msgs) {
-        switch (eContainerFeatureID()) {
-            case FeatureModelPackage.ATTRIBUTE__FEATURE:
-                return eInternalContainer().eInverseRemove(this, FeatureModelPackage.FEATURE__ATTRIBUTES, Feature.class, msgs);
-        }
-        return super.eBasicRemoveFromContainerFeature(msgs);
-    }
+		switch (eContainerFeatureID()) {
+			case FeatureModelPackage.ATTRIBUTE__FEATURE:
+				return eInternalContainer().eInverseRemove(this, FeatureModelPackage.FEATURE__ATTRIBUTES, Feature.class, msgs);
+		}
+		return super.eBasicRemoveFromContainerFeature(msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public AttributeType getType() {
-        return type;
-    }
+		return type;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setType(AttributeType newType) {
-        AttributeType oldType = type;
-        type = newType == null ? TYPE_EDEFAULT : newType;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__TYPE, oldType, type));
-    }
+		AttributeType oldType = type;
+		type = newType == null ? TYPE_EDEFAULT : newType;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__TYPE, oldType, type));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getValue() {
+		return value;
+	}
+
+				/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setValue(String newValue) {
+		String oldValue = value;
+		value = newValue;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.ATTRIBUTE__VALUE, oldValue, value));
+	}
+
+				/**
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureModelPackage.ATTRIBUTE__ID:
-                return getId();
-            case FeatureModelPackage.ATTRIBUTE__NAME:
-                return getName();
-            case FeatureModelPackage.ATTRIBUTE__TYPE:
-                return getType();
-            case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
-                return getDescription();
-            case FeatureModelPackage.ATTRIBUTE__COMMENT:
-                return getComment();
-            case FeatureModelPackage.ATTRIBUTE__FEATURE:
-                return getFeature();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.ATTRIBUTE__ID:
+				return getId();
+			case FeatureModelPackage.ATTRIBUTE__NAME:
+				return getName();
+			case FeatureModelPackage.ATTRIBUTE__TYPE:
+				return getType();
+			case FeatureModelPackage.ATTRIBUTE__VALUE:
+				return getValue();
+			case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
+				return getDescription();
+			case FeatureModelPackage.ATTRIBUTE__COMMENT:
+				return getComment();
+			case FeatureModelPackage.ATTRIBUTE__FEATURE:
+				return getFeature();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureModelPackage.ATTRIBUTE__ID:
-                setId((String)newValue);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__NAME:
-                setName((String)newValue);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__TYPE:
-                setType((AttributeType)newValue);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
-                setDescription((String)newValue);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__COMMENT:
-                setComment((String)newValue);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__FEATURE:
-                setFeature((Feature)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.ATTRIBUTE__ID:
+				setId((String)newValue);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__NAME:
+				setName((String)newValue);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__TYPE:
+				setType((AttributeType)newValue);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__VALUE:
+				setValue((String)newValue);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
+				setDescription((String)newValue);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__COMMENT:
+				setComment((String)newValue);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__FEATURE:
+				setFeature((Feature)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.ATTRIBUTE__ID:
-                setId(ID_EDEFAULT);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__NAME:
-                setName(NAME_EDEFAULT);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__TYPE:
-                setType(TYPE_EDEFAULT);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
-                setDescription(DESCRIPTION_EDEFAULT);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__COMMENT:
-                setComment(COMMENT_EDEFAULT);
-                return;
-            case FeatureModelPackage.ATTRIBUTE__FEATURE:
-                setFeature((Feature)null);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.ATTRIBUTE__ID:
+				setId(ID_EDEFAULT);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__NAME:
+				setName(NAME_EDEFAULT);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__TYPE:
+				setType(TYPE_EDEFAULT);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__VALUE:
+				setValue(VALUE_EDEFAULT);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
+				setDescription(DESCRIPTION_EDEFAULT);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__COMMENT:
+				setComment(COMMENT_EDEFAULT);
+				return;
+			case FeatureModelPackage.ATTRIBUTE__FEATURE:
+				setFeature((Feature)null);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.ATTRIBUTE__ID:
-                return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
-            case FeatureModelPackage.ATTRIBUTE__NAME:
-                return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
-            case FeatureModelPackage.ATTRIBUTE__TYPE:
-                return type != TYPE_EDEFAULT;
-            case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
-                return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
-            case FeatureModelPackage.ATTRIBUTE__COMMENT:
-                return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
-            case FeatureModelPackage.ATTRIBUTE__FEATURE:
-                return getFeature() != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.ATTRIBUTE__ID:
+				return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
+			case FeatureModelPackage.ATTRIBUTE__NAME:
+				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+			case FeatureModelPackage.ATTRIBUTE__TYPE:
+				return type != TYPE_EDEFAULT;
+			case FeatureModelPackage.ATTRIBUTE__VALUE:
+				return VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
+			case FeatureModelPackage.ATTRIBUTE__DESCRIPTION:
+				return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
+			case FeatureModelPackage.ATTRIBUTE__COMMENT:
+				return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
+			case FeatureModelPackage.ATTRIBUTE__FEATURE:
+				return getFeature() != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (id: ");
-        result.append(id);
-        result.append(", name: ");
-        result.append(name);
-        result.append(", type: ");
-        result.append(type);
-        result.append(", description: ");
-        result.append(description);
-        result.append(", comment: ");
-        result.append(comment);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (id: ");
+		result.append(id);
+		result.append(", name: ");
+		result.append(name);
+		result.append(", type: ");
+		result.append(type);
+		result.append(", value: ");
+		result.append(value);
+		result.append(", description: ");
+		result.append(description);
+		result.append(", comment: ");
+		result.append(comment);
+		result.append(')');
+		return result.toString();
+	}
 
 } //AttributeImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/ConstraintImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/ConstraintImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.ecore.impl.EObjectImpl;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.ConstraintImpl#getValue <em>Value</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.ConstraintImpl#getLanguage <em>Language</em>}</li>
@@ -27,203 +28,202 @@ import org.eclipse.emf.ecore.impl.EObjectImpl;
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.ConstraintImpl#getComment <em>Comment</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.ConstraintImpl#getFeatureModel <em>Feature Model</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class ConstraintImpl extends EObjectImpl implements Constraint {
     /**
-     * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String VALUE_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getValue()
-     * @generated
-     * @ordered
-     */
+	 * @see #getValue()
+	 * @generated
+	 * @ordered
+	 */
     protected String value = VALUE_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getLanguage() <em>Language</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getLanguage() <em>Language</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getLanguage()
-     * @generated
-     * @ordered
-     */
+	 * @see #getLanguage()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String LANGUAGE_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getLanguage() <em>Language</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getLanguage() <em>Language</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getLanguage()
-     * @generated
-     * @ordered
-     */
+	 * @see #getLanguage()
+	 * @generated
+	 * @ordered
+	 */
     protected String language = LANGUAGE_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String DESCRIPTION_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected String description = DESCRIPTION_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String COMMENT_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected String comment = COMMENT_EDEFAULT;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected ConstraintImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureModelPackage.Literals.CONSTRAINT;
-    }
+		return FeatureModelPackage.Literals.CONSTRAINT;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getValue() {
-        return value;
-    }
+		return value;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setValue(String newValue) {
-        String oldValue = value;
-        value = newValue;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.CONSTRAINT__VALUE, oldValue, value));
-    }
+		String oldValue = value;
+		value = newValue;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.CONSTRAINT__VALUE, oldValue, value));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getLanguage() {
-        return language;
-    }
+		return language;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setLanguage(String newLanguage) {
-        String oldLanguage = language;
-        language = newLanguage;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.CONSTRAINT__LANGUAGE, oldLanguage, language));
-    }
+		String oldLanguage = language;
+		language = newLanguage;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.CONSTRAINT__LANGUAGE, oldLanguage, language));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getDescription() {
-        return description;
-    }
+		return description;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setDescription(String newDescription) {
-        String oldDescription = description;
-        description = newDescription;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.CONSTRAINT__DESCRIPTION, oldDescription, description));
-    }
+		String oldDescription = description;
+		description = newDescription;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.CONSTRAINT__DESCRIPTION, oldDescription, description));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getComment() {
-        return comment;
-    }
+		return comment;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setComment(String newComment) {
-        String oldComment = comment;
-        comment = newComment;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.CONSTRAINT__COMMENT, oldComment, comment));
-    }
+		String oldComment = comment;
+		comment = newComment;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.CONSTRAINT__COMMENT, oldComment, comment));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModel getFeatureModel() {
-        FeatureModel featureModel = basicGetFeatureModel();
-        return featureModel != null && featureModel.eIsProxy() ? (FeatureModel)eResolveProxy((InternalEObject)featureModel) : featureModel;
-    }
+		FeatureModel featureModel = basicGetFeatureModel();
+		return featureModel != null && featureModel.eIsProxy() ? (FeatureModel)eResolveProxy((InternalEObject)featureModel) : featureModel;
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -235,118 +235,118 @@ public class ConstraintImpl extends EObjectImpl implements Constraint {
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureModelPackage.CONSTRAINT__VALUE:
-                return getValue();
-            case FeatureModelPackage.CONSTRAINT__LANGUAGE:
-                return getLanguage();
-            case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
-                return getDescription();
-            case FeatureModelPackage.CONSTRAINT__COMMENT:
-                return getComment();
-            case FeatureModelPackage.CONSTRAINT__FEATURE_MODEL:
-                if (resolve) return getFeatureModel();
-                return basicGetFeatureModel();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.CONSTRAINT__VALUE:
+				return getValue();
+			case FeatureModelPackage.CONSTRAINT__LANGUAGE:
+				return getLanguage();
+			case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
+				return getDescription();
+			case FeatureModelPackage.CONSTRAINT__COMMENT:
+				return getComment();
+			case FeatureModelPackage.CONSTRAINT__FEATURE_MODEL:
+				if (resolve) return getFeatureModel();
+				return basicGetFeatureModel();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureModelPackage.CONSTRAINT__VALUE:
-                setValue((String)newValue);
-                return;
-            case FeatureModelPackage.CONSTRAINT__LANGUAGE:
-                setLanguage((String)newValue);
-                return;
-            case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
-                setDescription((String)newValue);
-                return;
-            case FeatureModelPackage.CONSTRAINT__COMMENT:
-                setComment((String)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.CONSTRAINT__VALUE:
+				setValue((String)newValue);
+				return;
+			case FeatureModelPackage.CONSTRAINT__LANGUAGE:
+				setLanguage((String)newValue);
+				return;
+			case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
+				setDescription((String)newValue);
+				return;
+			case FeatureModelPackage.CONSTRAINT__COMMENT:
+				setComment((String)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.CONSTRAINT__VALUE:
-                setValue(VALUE_EDEFAULT);
-                return;
-            case FeatureModelPackage.CONSTRAINT__LANGUAGE:
-                setLanguage(LANGUAGE_EDEFAULT);
-                return;
-            case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
-                setDescription(DESCRIPTION_EDEFAULT);
-                return;
-            case FeatureModelPackage.CONSTRAINT__COMMENT:
-                setComment(COMMENT_EDEFAULT);
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.CONSTRAINT__VALUE:
+				setValue(VALUE_EDEFAULT);
+				return;
+			case FeatureModelPackage.CONSTRAINT__LANGUAGE:
+				setLanguage(LANGUAGE_EDEFAULT);
+				return;
+			case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
+				setDescription(DESCRIPTION_EDEFAULT);
+				return;
+			case FeatureModelPackage.CONSTRAINT__COMMENT:
+				setComment(COMMENT_EDEFAULT);
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.CONSTRAINT__VALUE:
-                return VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
-            case FeatureModelPackage.CONSTRAINT__LANGUAGE:
-                return LANGUAGE_EDEFAULT == null ? language != null : !LANGUAGE_EDEFAULT.equals(language);
-            case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
-                return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
-            case FeatureModelPackage.CONSTRAINT__COMMENT:
-                return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
-            case FeatureModelPackage.CONSTRAINT__FEATURE_MODEL:
-                return basicGetFeatureModel() != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.CONSTRAINT__VALUE:
+				return VALUE_EDEFAULT == null ? value != null : !VALUE_EDEFAULT.equals(value);
+			case FeatureModelPackage.CONSTRAINT__LANGUAGE:
+				return LANGUAGE_EDEFAULT == null ? language != null : !LANGUAGE_EDEFAULT.equals(language);
+			case FeatureModelPackage.CONSTRAINT__DESCRIPTION:
+				return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
+			case FeatureModelPackage.CONSTRAINT__COMMENT:
+				return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
+			case FeatureModelPackage.CONSTRAINT__FEATURE_MODEL:
+				return basicGetFeatureModel() != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (value: ");
-        result.append(value);
-        result.append(", language: ");
-        result.append(language);
-        result.append(", description: ");
-        result.append(description);
-        result.append(", comment: ");
-        result.append(comment);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (value: ");
+		result.append(value);
+		result.append(", language: ");
+		result.append(language);
+		result.append(", description: ");
+		result.append(description);
+		result.append(", comment: ");
+		result.append(comment);
+		result.append(')');
+		return result.toString();
+	}
 
 } //ConstraintImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/FeatureImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/FeatureImpl.java
@@ -29,6 +29,7 @@ import cz.zcu.yafmt.model.fm.Group;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.FeatureImpl#getId <em>Id</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.FeatureImpl#getName <em>Name</em>}</li>
@@ -49,365 +50,364 @@ import cz.zcu.yafmt.model.fm.Group;
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.FeatureImpl#getGroups <em>Groups</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.FeatureImpl#getFeatureModel <em>Feature Model</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class FeatureImpl extends EObjectImpl implements Feature {
     /**
-     * The default value of the '{@link #getId() <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String ID_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getId()
-     * @generated
-     * @ordered
-     */
+	 * @see #getId()
+	 * @generated
+	 * @ordered
+	 */
     protected String id = ID_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String NAME_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected String name = NAME_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String DESCRIPTION_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected String description = DESCRIPTION_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String COMMENT_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected String comment = COMMENT_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getLower() <em>Lower</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getLower() <em>Lower</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getLower()
-     * @generated
-     * @ordered
-     */
+	 * @see #getLower()
+	 * @generated
+	 * @ordered
+	 */
     protected static final int LOWER_EDEFAULT = 0;
 
     /**
-     * The cached value of the '{@link #getLower() <em>Lower</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getLower() <em>Lower</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getLower()
-     * @generated
-     * @ordered
-     */
+	 * @see #getLower()
+	 * @generated
+	 * @ordered
+	 */
     protected int lower = LOWER_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getUpper() <em>Upper</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getUpper() <em>Upper</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getUpper()
-     * @generated
-     * @ordered
-     */
+	 * @see #getUpper()
+	 * @generated
+	 * @ordered
+	 */
     protected static final int UPPER_EDEFAULT = 1;
 
     /**
-     * The cached value of the '{@link #getUpper() <em>Upper</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getUpper() <em>Upper</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getUpper()
-     * @generated
-     * @ordered
-     */
+	 * @see #getUpper()
+	 * @generated
+	 * @ordered
+	 */
     protected int upper = UPPER_EDEFAULT;
 
     /**
-     * The default value of the '{@link #isRoot() <em>Root</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isRoot() <em>Root</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isRoot()
-     * @generated
-     * @ordered
-     */
+	 * @see #isRoot()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean ROOT_EDEFAULT = false;
 
     /**
-     * The default value of the '{@link #isOrphan() <em>Orphan</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isOrphan() <em>Orphan</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isOrphan()
-     * @generated
-     * @ordered
-     */
+	 * @see #isOrphan()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean ORPHAN_EDEFAULT = false;
 
     /**
-     * The default value of the '{@link #isOptional() <em>Optional</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isOptional() <em>Optional</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isOptional()
-     * @generated
-     * @ordered
-     */
+	 * @see #isOptional()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean OPTIONAL_EDEFAULT = false;
 
     /**
-     * The default value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isMandatory() <em>Mandatory</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isMandatory()
-     * @generated
-     * @ordered
-     */
+	 * @see #isMandatory()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean MANDATORY_EDEFAULT = false;
 
     /**
-     * The default value of the '{@link #isCloneable() <em>Cloneable</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isCloneable() <em>Cloneable</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isCloneable()
-     * @generated
-     * @ordered
-     */
+	 * @see #isCloneable()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean CLONEABLE_EDEFAULT = false;
 
     /**
-     * The cached value of the '{@link #getAttributes() <em>Attributes</em>}' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getAttributes() <em>Attributes</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getAttributes()
-     * @generated
-     * @ordered
-     */
+	 * @see #getAttributes()
+	 * @generated
+	 * @ordered
+	 */
     protected EList<Attribute> attributes;
 
     /**
-     * The cached value of the '{@link #getFeatures() <em>Features</em>}' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getFeatures() <em>Features</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getFeatures()
-     * @generated
-     * @ordered
-     */
+	 * @see #getFeatures()
+	 * @generated
+	 * @ordered
+	 */
     protected EList<Feature> features;
 
     /**
-     * The cached value of the '{@link #getGroups() <em>Groups</em>}' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getGroups() <em>Groups</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getGroups()
-     * @generated
-     * @ordered
-     */
+	 * @see #getGroups()
+	 * @generated
+	 * @ordered
+	 */
     protected EList<Group> groups;
 
     /**
-     * The cached value of the '{@link #getFeatureModel() <em>Feature Model</em>}' reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getFeatureModel() <em>Feature Model</em>}' reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getFeatureModel()
-     * @generated
-     * @ordered
-     */
+	 * @see #getFeatureModel()
+	 * @generated
+	 * @ordered
+	 */
     protected FeatureModel featureModel;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected FeatureImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureModelPackage.Literals.FEATURE;
-    }
+		return FeatureModelPackage.Literals.FEATURE;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getId() {
-        return id;
-    }
+		return id;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setId(String newId) {
-        String oldId = id;
-        id = newId;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__ID, oldId, id));
-    }
+		String oldId = id;
+		id = newId;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__ID, oldId, id));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getName() {
-        return name;
-    }
+		return name;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setName(String newName) {
-        String oldName = name;
-        name = newName;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__NAME, oldName, name));
-    }
+		String oldName = name;
+		name = newName;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__NAME, oldName, name));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getDescription() {
-        return description;
-    }
+		return description;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setDescription(String newDescription) {
-        String oldDescription = description;
-        description = newDescription;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__DESCRIPTION, oldDescription, description));
-    }
+		String oldDescription = description;
+		description = newDescription;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__DESCRIPTION, oldDescription, description));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getComment() {
-        return comment;
-    }
+		return comment;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setComment(String newComment) {
-        String oldComment = comment;
-        comment = newComment;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__COMMENT, oldComment, comment));
-    }
+		String oldComment = comment;
+		comment = newComment;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__COMMENT, oldComment, comment));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public int getLower() {
-        return lower;
-    }
+		return lower;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setLower(int newLower) {
-        int oldLower = lower;
-        lower = newLower;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__LOWER, oldLower, lower));
-    }
+		int oldLower = lower;
+		lower = newLower;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__LOWER, oldLower, lower));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public int getUpper() {
-        return upper;
-    }
+		return upper;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setUpper(int newUpper) {
-        int oldUpper = upper;
-        upper = newUpper;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__UPPER, oldUpper, upper));
-    }
+		int oldUpper = upper;
+		upper = newUpper;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__UPPER, oldUpper, upper));
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -487,26 +487,26 @@ public class FeatureImpl extends EObjectImpl implements Feature {
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EList<Attribute> getAttributes() {
-        if (attributes == null) {
-            attributes = new EObjectContainmentWithInverseEList<Attribute>(Attribute.class, this, FeatureModelPackage.FEATURE__ATTRIBUTES, FeatureModelPackage.ATTRIBUTE__FEATURE);
-        }
-        return attributes;
-    }
+		if (attributes == null) {
+			attributes = new EObjectContainmentWithInverseEList<Attribute>(Attribute.class, this, FeatureModelPackage.FEATURE__ATTRIBUTES, FeatureModelPackage.ATTRIBUTE__FEATURE);
+		}
+		return attributes;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EObject getParent() {
-        EObject parent = basicGetParent();
-        return parent != null && parent.eIsProxy() ? eResolveProxy((InternalEObject)parent) : parent;
-    }
+		EObject parent = basicGetParent();
+		return parent != null && parent.eIsProxy() ? eResolveProxy((InternalEObject)parent) : parent;
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -534,110 +534,110 @@ public class FeatureImpl extends EObjectImpl implements Feature {
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Feature getParentFeature() {
-        if (eContainerFeatureID() != FeatureModelPackage.FEATURE__PARENT_FEATURE) return null;
-        return (Feature)eContainer();
-    }
+		if (eContainerFeatureID() != FeatureModelPackage.FEATURE__PARENT_FEATURE) return null;
+		return (Feature)eInternalContainer();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetParentFeature(Feature newParentFeature, NotificationChain msgs) {
-        msgs = eBasicSetContainer((InternalEObject)newParentFeature, FeatureModelPackage.FEATURE__PARENT_FEATURE, msgs);
-        return msgs;
-    }
+		msgs = eBasicSetContainer((InternalEObject)newParentFeature, FeatureModelPackage.FEATURE__PARENT_FEATURE, msgs);
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setParentFeature(Feature newParentFeature) {
-        if (newParentFeature != eInternalContainer() || (eContainerFeatureID() != FeatureModelPackage.FEATURE__PARENT_FEATURE && newParentFeature != null)) {
-            if (EcoreUtil.isAncestor(this, newParentFeature))
-                throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
-            NotificationChain msgs = null;
-            if (eInternalContainer() != null)
-                msgs = eBasicRemoveFromContainer(msgs);
-            if (newParentFeature != null)
-                msgs = ((InternalEObject)newParentFeature).eInverseAdd(this, FeatureModelPackage.FEATURE__FEATURES, Feature.class, msgs);
-            msgs = basicSetParentFeature(newParentFeature, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__PARENT_FEATURE, newParentFeature, newParentFeature));
-    }
+		if (newParentFeature != eInternalContainer() || (eContainerFeatureID() != FeatureModelPackage.FEATURE__PARENT_FEATURE && newParentFeature != null)) {
+			if (EcoreUtil.isAncestor(this, newParentFeature))
+				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
+			NotificationChain msgs = null;
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
+			if (newParentFeature != null)
+				msgs = ((InternalEObject)newParentFeature).eInverseAdd(this, FeatureModelPackage.FEATURE__FEATURES, Feature.class, msgs);
+			msgs = basicSetParentFeature(newParentFeature, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__PARENT_FEATURE, newParentFeature, newParentFeature));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Group getParentGroup() {
-        if (eContainerFeatureID() != FeatureModelPackage.FEATURE__PARENT_GROUP) return null;
-        return (Group)eContainer();
-    }
+		if (eContainerFeatureID() != FeatureModelPackage.FEATURE__PARENT_GROUP) return null;
+		return (Group)eInternalContainer();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetParentGroup(Group newParentGroup, NotificationChain msgs) {
-        msgs = eBasicSetContainer((InternalEObject)newParentGroup, FeatureModelPackage.FEATURE__PARENT_GROUP, msgs);
-        return msgs;
-    }
+		msgs = eBasicSetContainer((InternalEObject)newParentGroup, FeatureModelPackage.FEATURE__PARENT_GROUP, msgs);
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setParentGroup(Group newParentGroup) {
-        if (newParentGroup != eInternalContainer() || (eContainerFeatureID() != FeatureModelPackage.FEATURE__PARENT_GROUP && newParentGroup != null)) {
-            if (EcoreUtil.isAncestor(this, newParentGroup))
-                throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
-            NotificationChain msgs = null;
-            if (eInternalContainer() != null)
-                msgs = eBasicRemoveFromContainer(msgs);
-            if (newParentGroup != null)
-                msgs = ((InternalEObject)newParentGroup).eInverseAdd(this, FeatureModelPackage.GROUP__FEATURES, Group.class, msgs);
-            msgs = basicSetParentGroup(newParentGroup, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__PARENT_GROUP, newParentGroup, newParentGroup));
-    }
+		if (newParentGroup != eInternalContainer() || (eContainerFeatureID() != FeatureModelPackage.FEATURE__PARENT_GROUP && newParentGroup != null)) {
+			if (EcoreUtil.isAncestor(this, newParentGroup))
+				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
+			NotificationChain msgs = null;
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
+			if (newParentGroup != null)
+				msgs = ((InternalEObject)newParentGroup).eInverseAdd(this, FeatureModelPackage.GROUP__FEATURES, Group.class, msgs);
+			msgs = basicSetParentGroup(newParentGroup, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE__PARENT_GROUP, newParentGroup, newParentGroup));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EList<Feature> getFeatures() {
-        if (features == null) {
-            features = new EObjectContainmentWithInverseEList<Feature>(Feature.class, this, FeatureModelPackage.FEATURE__FEATURES, FeatureModelPackage.FEATURE__PARENT_FEATURE);
-        }
-        return features;
-    }
+		if (features == null) {
+			features = new EObjectContainmentWithInverseEList<Feature>(Feature.class, this, FeatureModelPackage.FEATURE__FEATURES, FeatureModelPackage.FEATURE__PARENT_FEATURE);
+		}
+		return features;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EList<Group> getGroups() {
-        if (groups == null) {
-            groups = new EObjectContainmentWithInverseEList<Group>(Group.class, this, FeatureModelPackage.FEATURE__GROUPS, FeatureModelPackage.GROUP__PARENT);
-        }
-        return groups;
-    }
+		if (groups == null) {
+			groups = new EObjectContainmentWithInverseEList<Group>(Group.class, this, FeatureModelPackage.FEATURE__GROUPS, FeatureModelPackage.GROUP__PARENT);
+		}
+		return groups;
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -684,304 +684,304 @@ public class FeatureImpl extends EObjectImpl implements Feature {
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @SuppressWarnings("unchecked")
     @Override
     public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE__PARENT_FEATURE:
-                if (eInternalContainer() != null)
-                    msgs = eBasicRemoveFromContainer(msgs);
-                return basicSetParentFeature((Feature)otherEnd, msgs);
-            case FeatureModelPackage.FEATURE__PARENT_GROUP:
-                if (eInternalContainer() != null)
-                    msgs = eBasicRemoveFromContainer(msgs);
-                return basicSetParentGroup((Group)otherEnd, msgs);
-            case FeatureModelPackage.FEATURE__ATTRIBUTES:
-                return ((InternalEList<InternalEObject>)(InternalEList<?>)getAttributes()).basicAdd(otherEnd, msgs);
-            case FeatureModelPackage.FEATURE__FEATURES:
-                return ((InternalEList<InternalEObject>)(InternalEList<?>)getFeatures()).basicAdd(otherEnd, msgs);
-            case FeatureModelPackage.FEATURE__GROUPS:
-                return ((InternalEList<InternalEObject>)(InternalEList<?>)getGroups()).basicAdd(otherEnd, msgs);
-        }
-        return super.eInverseAdd(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE__PARENT_FEATURE:
+				if (eInternalContainer() != null)
+					msgs = eBasicRemoveFromContainer(msgs);
+				return basicSetParentFeature((Feature)otherEnd, msgs);
+			case FeatureModelPackage.FEATURE__PARENT_GROUP:
+				if (eInternalContainer() != null)
+					msgs = eBasicRemoveFromContainer(msgs);
+				return basicSetParentGroup((Group)otherEnd, msgs);
+			case FeatureModelPackage.FEATURE__ATTRIBUTES:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getAttributes()).basicAdd(otherEnd, msgs);
+			case FeatureModelPackage.FEATURE__FEATURES:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getFeatures()).basicAdd(otherEnd, msgs);
+			case FeatureModelPackage.FEATURE__GROUPS:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getGroups()).basicAdd(otherEnd, msgs);
+		}
+		return super.eInverseAdd(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE__PARENT_FEATURE:
-                return basicSetParentFeature(null, msgs);
-            case FeatureModelPackage.FEATURE__PARENT_GROUP:
-                return basicSetParentGroup(null, msgs);
-            case FeatureModelPackage.FEATURE__ATTRIBUTES:
-                return ((InternalEList<?>)getAttributes()).basicRemove(otherEnd, msgs);
-            case FeatureModelPackage.FEATURE__FEATURES:
-                return ((InternalEList<?>)getFeatures()).basicRemove(otherEnd, msgs);
-            case FeatureModelPackage.FEATURE__GROUPS:
-                return ((InternalEList<?>)getGroups()).basicRemove(otherEnd, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE__PARENT_FEATURE:
+				return basicSetParentFeature(null, msgs);
+			case FeatureModelPackage.FEATURE__PARENT_GROUP:
+				return basicSetParentGroup(null, msgs);
+			case FeatureModelPackage.FEATURE__ATTRIBUTES:
+				return ((InternalEList<?>)getAttributes()).basicRemove(otherEnd, msgs);
+			case FeatureModelPackage.FEATURE__FEATURES:
+				return ((InternalEList<?>)getFeatures()).basicRemove(otherEnd, msgs);
+			case FeatureModelPackage.FEATURE__GROUPS:
+				return ((InternalEList<?>)getGroups()).basicRemove(otherEnd, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eBasicRemoveFromContainerFeature(NotificationChain msgs) {
-        switch (eContainerFeatureID()) {
-            case FeatureModelPackage.FEATURE__PARENT_FEATURE:
-                return eInternalContainer().eInverseRemove(this, FeatureModelPackage.FEATURE__FEATURES, Feature.class, msgs);
-            case FeatureModelPackage.FEATURE__PARENT_GROUP:
-                return eInternalContainer().eInverseRemove(this, FeatureModelPackage.GROUP__FEATURES, Group.class, msgs);
-        }
-        return super.eBasicRemoveFromContainerFeature(msgs);
-    }
+		switch (eContainerFeatureID()) {
+			case FeatureModelPackage.FEATURE__PARENT_FEATURE:
+				return eInternalContainer().eInverseRemove(this, FeatureModelPackage.FEATURE__FEATURES, Feature.class, msgs);
+			case FeatureModelPackage.FEATURE__PARENT_GROUP:
+				return eInternalContainer().eInverseRemove(this, FeatureModelPackage.GROUP__FEATURES, Group.class, msgs);
+		}
+		return super.eBasicRemoveFromContainerFeature(msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE__ID:
-                return getId();
-            case FeatureModelPackage.FEATURE__NAME:
-                return getName();
-            case FeatureModelPackage.FEATURE__DESCRIPTION:
-                return getDescription();
-            case FeatureModelPackage.FEATURE__COMMENT:
-                return getComment();
-            case FeatureModelPackage.FEATURE__LOWER:
-                return getLower();
-            case FeatureModelPackage.FEATURE__UPPER:
-                return getUpper();
-            case FeatureModelPackage.FEATURE__ROOT:
-                return isRoot();
-            case FeatureModelPackage.FEATURE__ORPHAN:
-                return isOrphan();
-            case FeatureModelPackage.FEATURE__OPTIONAL:
-                return isOptional();
-            case FeatureModelPackage.FEATURE__MANDATORY:
-                return isMandatory();
-            case FeatureModelPackage.FEATURE__CLONEABLE:
-                return isCloneable();
-            case FeatureModelPackage.FEATURE__PARENT:
-                if (resolve) return getParent();
-                return basicGetParent();
-            case FeatureModelPackage.FEATURE__PARENT_FEATURE:
-                return getParentFeature();
-            case FeatureModelPackage.FEATURE__PARENT_GROUP:
-                return getParentGroup();
-            case FeatureModelPackage.FEATURE__ATTRIBUTES:
-                return getAttributes();
-            case FeatureModelPackage.FEATURE__FEATURES:
-                return getFeatures();
-            case FeatureModelPackage.FEATURE__GROUPS:
-                return getGroups();
-            case FeatureModelPackage.FEATURE__FEATURE_MODEL:
-                if (resolve) return getFeatureModel();
-                return basicGetFeatureModel();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE__ID:
+				return getId();
+			case FeatureModelPackage.FEATURE__NAME:
+				return getName();
+			case FeatureModelPackage.FEATURE__DESCRIPTION:
+				return getDescription();
+			case FeatureModelPackage.FEATURE__COMMENT:
+				return getComment();
+			case FeatureModelPackage.FEATURE__LOWER:
+				return getLower();
+			case FeatureModelPackage.FEATURE__UPPER:
+				return getUpper();
+			case FeatureModelPackage.FEATURE__ROOT:
+				return isRoot();
+			case FeatureModelPackage.FEATURE__ORPHAN:
+				return isOrphan();
+			case FeatureModelPackage.FEATURE__OPTIONAL:
+				return isOptional();
+			case FeatureModelPackage.FEATURE__MANDATORY:
+				return isMandatory();
+			case FeatureModelPackage.FEATURE__CLONEABLE:
+				return isCloneable();
+			case FeatureModelPackage.FEATURE__PARENT:
+				if (resolve) return getParent();
+				return basicGetParent();
+			case FeatureModelPackage.FEATURE__PARENT_FEATURE:
+				return getParentFeature();
+			case FeatureModelPackage.FEATURE__PARENT_GROUP:
+				return getParentGroup();
+			case FeatureModelPackage.FEATURE__ATTRIBUTES:
+				return getAttributes();
+			case FeatureModelPackage.FEATURE__FEATURES:
+				return getFeatures();
+			case FeatureModelPackage.FEATURE__GROUPS:
+				return getGroups();
+			case FeatureModelPackage.FEATURE__FEATURE_MODEL:
+				if (resolve) return getFeatureModel();
+				return basicGetFeatureModel();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @SuppressWarnings("unchecked")
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE__ID:
-                setId((String)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__NAME:
-                setName((String)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__DESCRIPTION:
-                setDescription((String)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__COMMENT:
-                setComment((String)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__LOWER:
-                setLower((Integer)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__UPPER:
-                setUpper((Integer)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__OPTIONAL:
-                setOptional((Boolean)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__MANDATORY:
-                setMandatory((Boolean)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__PARENT:
-                setParent((EObject)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__PARENT_FEATURE:
-                setParentFeature((Feature)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__PARENT_GROUP:
-                setParentGroup((Group)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__ATTRIBUTES:
-                getAttributes().clear();
-                getAttributes().addAll((Collection<? extends Attribute>)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__FEATURES:
-                getFeatures().clear();
-                getFeatures().addAll((Collection<? extends Feature>)newValue);
-                return;
-            case FeatureModelPackage.FEATURE__GROUPS:
-                getGroups().clear();
-                getGroups().addAll((Collection<? extends Group>)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE__ID:
+				setId((String)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__NAME:
+				setName((String)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__DESCRIPTION:
+				setDescription((String)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__COMMENT:
+				setComment((String)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__LOWER:
+				setLower((Integer)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__UPPER:
+				setUpper((Integer)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__OPTIONAL:
+				setOptional((Boolean)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__MANDATORY:
+				setMandatory((Boolean)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__PARENT:
+				setParent((EObject)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__PARENT_FEATURE:
+				setParentFeature((Feature)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__PARENT_GROUP:
+				setParentGroup((Group)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__ATTRIBUTES:
+				getAttributes().clear();
+				getAttributes().addAll((Collection<? extends Attribute>)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__FEATURES:
+				getFeatures().clear();
+				getFeatures().addAll((Collection<? extends Feature>)newValue);
+				return;
+			case FeatureModelPackage.FEATURE__GROUPS:
+				getGroups().clear();
+				getGroups().addAll((Collection<? extends Group>)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE__ID:
-                setId(ID_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE__NAME:
-                setName(NAME_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE__DESCRIPTION:
-                setDescription(DESCRIPTION_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE__COMMENT:
-                setComment(COMMENT_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE__LOWER:
-                setLower(LOWER_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE__UPPER:
-                setUpper(UPPER_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE__OPTIONAL:
-                setOptional(OPTIONAL_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE__MANDATORY:
-                setMandatory(MANDATORY_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE__PARENT:
-                setParent((EObject)null);
-                return;
-            case FeatureModelPackage.FEATURE__PARENT_FEATURE:
-                setParentFeature((Feature)null);
-                return;
-            case FeatureModelPackage.FEATURE__PARENT_GROUP:
-                setParentGroup((Group)null);
-                return;
-            case FeatureModelPackage.FEATURE__ATTRIBUTES:
-                getAttributes().clear();
-                return;
-            case FeatureModelPackage.FEATURE__FEATURES:
-                getFeatures().clear();
-                return;
-            case FeatureModelPackage.FEATURE__GROUPS:
-                getGroups().clear();
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE__ID:
+				setId(ID_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE__NAME:
+				setName(NAME_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE__DESCRIPTION:
+				setDescription(DESCRIPTION_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE__COMMENT:
+				setComment(COMMENT_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE__LOWER:
+				setLower(LOWER_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE__UPPER:
+				setUpper(UPPER_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE__OPTIONAL:
+				setOptional(OPTIONAL_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE__MANDATORY:
+				setMandatory(MANDATORY_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE__PARENT:
+				setParent((EObject)null);
+				return;
+			case FeatureModelPackage.FEATURE__PARENT_FEATURE:
+				setParentFeature((Feature)null);
+				return;
+			case FeatureModelPackage.FEATURE__PARENT_GROUP:
+				setParentGroup((Group)null);
+				return;
+			case FeatureModelPackage.FEATURE__ATTRIBUTES:
+				getAttributes().clear();
+				return;
+			case FeatureModelPackage.FEATURE__FEATURES:
+				getFeatures().clear();
+				return;
+			case FeatureModelPackage.FEATURE__GROUPS:
+				getGroups().clear();
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE__ID:
-                return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
-            case FeatureModelPackage.FEATURE__NAME:
-                return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
-            case FeatureModelPackage.FEATURE__DESCRIPTION:
-                return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
-            case FeatureModelPackage.FEATURE__COMMENT:
-                return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
-            case FeatureModelPackage.FEATURE__LOWER:
-                return lower != LOWER_EDEFAULT;
-            case FeatureModelPackage.FEATURE__UPPER:
-                return upper != UPPER_EDEFAULT;
-            case FeatureModelPackage.FEATURE__ROOT:
-                return isRoot() != ROOT_EDEFAULT;
-            case FeatureModelPackage.FEATURE__ORPHAN:
-                return isOrphan() != ORPHAN_EDEFAULT;
-            case FeatureModelPackage.FEATURE__OPTIONAL:
-                return isOptional() != OPTIONAL_EDEFAULT;
-            case FeatureModelPackage.FEATURE__MANDATORY:
-                return isMandatory() != MANDATORY_EDEFAULT;
-            case FeatureModelPackage.FEATURE__CLONEABLE:
-                return isCloneable() != CLONEABLE_EDEFAULT;
-            case FeatureModelPackage.FEATURE__PARENT:
-                return basicGetParent() != null;
-            case FeatureModelPackage.FEATURE__PARENT_FEATURE:
-                return getParentFeature() != null;
-            case FeatureModelPackage.FEATURE__PARENT_GROUP:
-                return getParentGroup() != null;
-            case FeatureModelPackage.FEATURE__ATTRIBUTES:
-                return attributes != null && !attributes.isEmpty();
-            case FeatureModelPackage.FEATURE__FEATURES:
-                return features != null && !features.isEmpty();
-            case FeatureModelPackage.FEATURE__GROUPS:
-                return groups != null && !groups.isEmpty();
-            case FeatureModelPackage.FEATURE__FEATURE_MODEL:
-                return featureModel != null;
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE__ID:
+				return ID_EDEFAULT == null ? id != null : !ID_EDEFAULT.equals(id);
+			case FeatureModelPackage.FEATURE__NAME:
+				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+			case FeatureModelPackage.FEATURE__DESCRIPTION:
+				return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
+			case FeatureModelPackage.FEATURE__COMMENT:
+				return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
+			case FeatureModelPackage.FEATURE__LOWER:
+				return lower != LOWER_EDEFAULT;
+			case FeatureModelPackage.FEATURE__UPPER:
+				return upper != UPPER_EDEFAULT;
+			case FeatureModelPackage.FEATURE__ROOT:
+				return isRoot() != ROOT_EDEFAULT;
+			case FeatureModelPackage.FEATURE__ORPHAN:
+				return isOrphan() != ORPHAN_EDEFAULT;
+			case FeatureModelPackage.FEATURE__OPTIONAL:
+				return isOptional() != OPTIONAL_EDEFAULT;
+			case FeatureModelPackage.FEATURE__MANDATORY:
+				return isMandatory() != MANDATORY_EDEFAULT;
+			case FeatureModelPackage.FEATURE__CLONEABLE:
+				return isCloneable() != CLONEABLE_EDEFAULT;
+			case FeatureModelPackage.FEATURE__PARENT:
+				return basicGetParent() != null;
+			case FeatureModelPackage.FEATURE__PARENT_FEATURE:
+				return getParentFeature() != null;
+			case FeatureModelPackage.FEATURE__PARENT_GROUP:
+				return getParentGroup() != null;
+			case FeatureModelPackage.FEATURE__ATTRIBUTES:
+				return attributes != null && !attributes.isEmpty();
+			case FeatureModelPackage.FEATURE__FEATURES:
+				return features != null && !features.isEmpty();
+			case FeatureModelPackage.FEATURE__GROUPS:
+				return groups != null && !groups.isEmpty();
+			case FeatureModelPackage.FEATURE__FEATURE_MODEL:
+				return featureModel != null;
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (id: ");
-        result.append(id);
-        result.append(", name: ");
-        result.append(name);
-        result.append(", description: ");
-        result.append(description);
-        result.append(", comment: ");
-        result.append(comment);
-        result.append(", lower: ");
-        result.append(lower);
-        result.append(", upper: ");
-        result.append(upper);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (id: ");
+		result.append(id);
+		result.append(", name: ");
+		result.append(name);
+		result.append(", description: ");
+		result.append(description);
+		result.append(", comment: ");
+		result.append(comment);
+		result.append(", lower: ");
+		result.append(lower);
+		result.append(", upper: ");
+		result.append(upper);
+		result.append(')');
+		return result.toString();
+	}
 
 } //FeatureImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/FeatureModelFactoryImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/FeatureModelFactoryImpl.java
@@ -21,170 +21,170 @@ import org.eclipse.emf.ecore.plugin.EcorePlugin;
  */
 public class FeatureModelFactoryImpl extends EFactoryImpl implements FeatureModelFactory {
     /**
-     * Creates the default factory implementation.
-     * <!-- begin-user-doc -->
+	 * Creates the default factory implementation.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public static FeatureModelFactory init() {
-        try {
-            FeatureModelFactory theFeatureModelFactory = (FeatureModelFactory)EPackage.Registry.INSTANCE.getEFactory("http://zcu.cz/yafmt/model/fm"); 
-            if (theFeatureModelFactory != null) {
-                return theFeatureModelFactory;
-            }
-        }
-        catch (Exception exception) {
-            EcorePlugin.INSTANCE.log(exception);
-        }
-        return new FeatureModelFactoryImpl();
-    }
+		try {
+			FeatureModelFactory theFeatureModelFactory = (FeatureModelFactory)EPackage.Registry.INSTANCE.getEFactory(FeatureModelPackage.eNS_URI);
+			if (theFeatureModelFactory != null) {
+				return theFeatureModelFactory;
+			}
+		}
+		catch (Exception exception) {
+			EcorePlugin.INSTANCE.log(exception);
+		}
+		return new FeatureModelFactoryImpl();
+	}
 
     /**
-     * Creates an instance of the factory.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModelFactoryImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public EObject create(EClass eClass) {
-        switch (eClass.getClassifierID()) {
-            case FeatureModelPackage.FEATURE_MODEL: return createFeatureModel();
-            case FeatureModelPackage.FEATURE: return createFeature();
-            case FeatureModelPackage.GROUP: return createGroup();
-            case FeatureModelPackage.ATTRIBUTE: return createAttribute();
-            case FeatureModelPackage.CONSTRAINT: return createConstraint();
-            default:
-                throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
-        }
-    }
+		switch (eClass.getClassifierID()) {
+			case FeatureModelPackage.FEATURE_MODEL: return createFeatureModel();
+			case FeatureModelPackage.FEATURE: return createFeature();
+			case FeatureModelPackage.GROUP: return createGroup();
+			case FeatureModelPackage.ATTRIBUTE: return createAttribute();
+			case FeatureModelPackage.CONSTRAINT: return createConstraint();
+			default:
+				throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier");
+		}
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object createFromString(EDataType eDataType, String initialValue) {
-        switch (eDataType.getClassifierID()) {
-            case FeatureModelPackage.ATTRIBUTE_TYPE:
-                return createAttributeTypeFromString(eDataType, initialValue);
-            default:
-                throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
-        }
-    }
+		switch (eDataType.getClassifierID()) {
+			case FeatureModelPackage.ATTRIBUTE_TYPE:
+				return createAttributeTypeFromString(eDataType, initialValue);
+			default:
+				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
+		}
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String convertToString(EDataType eDataType, Object instanceValue) {
-        switch (eDataType.getClassifierID()) {
-            case FeatureModelPackage.ATTRIBUTE_TYPE:
-                return convertAttributeTypeToString(eDataType, instanceValue);
-            default:
-                throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
-        }
-    }
+		switch (eDataType.getClassifierID()) {
+			case FeatureModelPackage.ATTRIBUTE_TYPE:
+				return convertAttributeTypeToString(eDataType, instanceValue);
+			default:
+				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
+		}
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModel createFeatureModel() {
-        FeatureModelImpl featureModel = new FeatureModelImpl();
-        return featureModel;
-    }
+		FeatureModelImpl featureModel = new FeatureModelImpl();
+		return featureModel;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Feature createFeature() {
-        FeatureImpl feature = new FeatureImpl();
-        return feature;
-    }
+		FeatureImpl feature = new FeatureImpl();
+		return feature;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Group createGroup() {
-        GroupImpl group = new GroupImpl();
-        return group;
-    }
+		GroupImpl group = new GroupImpl();
+		return group;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Attribute createAttribute() {
-        AttributeImpl attribute = new AttributeImpl();
-        return attribute;
-    }
+		AttributeImpl attribute = new AttributeImpl();
+		return attribute;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Constraint createConstraint() {
-        ConstraintImpl constraint = new ConstraintImpl();
-        return constraint;
-    }
+		ConstraintImpl constraint = new ConstraintImpl();
+		return constraint;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public AttributeType createAttributeTypeFromString(EDataType eDataType, String initialValue) {
-        AttributeType result = AttributeType.get(initialValue);
-        if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
-        return result;
-    }
+		AttributeType result = AttributeType.get(initialValue);
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
+		return result;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String convertAttributeTypeToString(EDataType eDataType, Object instanceValue) {
-        return instanceValue == null ? null : instanceValue.toString();
-    }
+		return instanceValue == null ? null : instanceValue.toString();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModelPackage getFeatureModelPackage() {
-        return (FeatureModelPackage)getEPackage();
-    }
+		return (FeatureModelPackage)getEPackage();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @deprecated
-     * @generated
-     */
+	 * @deprecated
+	 * @generated
+	 */
     @Deprecated
     public static FeatureModelPackage getPackage() {
-        return FeatureModelPackage.eINSTANCE;
-    }
+		return FeatureModelPackage.eINSTANCE;
+	}
 
 } //FeatureModelFactoryImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/FeatureModelImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/FeatureModelImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.FeatureModelImpl#getName <em>Name</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.FeatureModelImpl#getVersion <em>Version</em>}</li>
@@ -39,119 +40,118 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.FeatureModelImpl#getOrphans <em>Orphans</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.FeatureModelImpl#getConstraints <em>Constraints</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class FeatureModelImpl extends EObjectImpl implements FeatureModel {
     /**
-     * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String NAME_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getName()
-     * @generated
-     * @ordered
-     */
+	 * @see #getName()
+	 * @generated
+	 * @ordered
+	 */
     protected String name = NAME_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getVersion() <em>Version</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getVersion() <em>Version</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getVersion()
-     * @generated
-     * @ordered
-     */
+	 * @see #getVersion()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String VERSION_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getVersion()
-     * @generated
-     * @ordered
-     */
+	 * @see #getVersion()
+	 * @generated
+	 * @ordered
+	 */
     protected String version = VERSION_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String DESCRIPTION_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected String description = DESCRIPTION_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String COMMENT_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected String comment = COMMENT_EDEFAULT;
 
     /**
-     * The cached value of the '{@link #getRoot() <em>Root</em>}' containment reference.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getRoot() <em>Root</em>}' containment reference.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getRoot()
-     * @generated
-     * @ordered
-     */
+	 * @see #getRoot()
+	 * @generated
+	 * @ordered
+	 */
     protected Feature root;
 
     /**
-     * The cached value of the '{@link #getOrphans() <em>Orphans</em>}' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getOrphans() <em>Orphans</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getOrphans()
-     * @generated
-     * @ordered
-     */
+	 * @see #getOrphans()
+	 * @generated
+	 * @ordered
+	 */
     protected EList<Feature> orphans;
 
     /**
-     * The cached value of the '{@link #getConstraints() <em>Constraints</em>}' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getConstraints() <em>Constraints</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getConstraints()
-     * @generated
-     * @ordered
-     */
+	 * @see #getConstraints()
+	 * @generated
+	 * @ordered
+	 */
     protected EList<Constraint> constraints;
     
     /**
@@ -160,174 +160,174 @@ public class FeatureModelImpl extends EObjectImpl implements FeatureModel {
     private FeatureCache featureCache;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected FeatureModelImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureModelPackage.Literals.FEATURE_MODEL;
-    }
+		return FeatureModelPackage.Literals.FEATURE_MODEL;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getName() {
-        return name;
-    }
+		return name;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setName(String newName) {
-        String oldName = name;
-        name = newName;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__NAME, oldName, name));
-    }
+		String oldName = name;
+		name = newName;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__NAME, oldName, name));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getDescription() {
-        return description;
-    }
+		return description;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setDescription(String newDescription) {
-        String oldDescription = description;
-        description = newDescription;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__DESCRIPTION, oldDescription, description));
-    }
+		String oldDescription = description;
+		description = newDescription;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__DESCRIPTION, oldDescription, description));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getComment() {
-        return comment;
-    }
+		return comment;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setComment(String newComment) {
-        String oldComment = comment;
-        comment = newComment;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__COMMENT, oldComment, comment));
-    }
+		String oldComment = comment;
+		comment = newComment;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__COMMENT, oldComment, comment));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getVersion() {
-        return version;
-    }
+		return version;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setVersion(String newVersion) {
-        String oldVersion = version;
-        version = newVersion;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__VERSION, oldVersion, version));
-    }
+		String oldVersion = version;
+		version = newVersion;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__VERSION, oldVersion, version));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Feature getRoot() {
-        return root;
-    }
+		return root;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetRoot(Feature newRoot, NotificationChain msgs) {
-        Feature oldRoot = root;
-        root = newRoot;
-        if (eNotificationRequired()) {
-            ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__ROOT, oldRoot, newRoot);
-            if (msgs == null) msgs = notification; else msgs.add(notification);
-        }
-        return msgs;
-    }
+		Feature oldRoot = root;
+		root = newRoot;
+		if (eNotificationRequired()) {
+			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__ROOT, oldRoot, newRoot);
+			if (msgs == null) msgs = notification; else msgs.add(notification);
+		}
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setRoot(Feature newRoot) {
-        if (newRoot != root) {
-            NotificationChain msgs = null;
-            if (root != null)
-                msgs = ((InternalEObject)root).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - FeatureModelPackage.FEATURE_MODEL__ROOT, null, msgs);
-            if (newRoot != null)
-                msgs = ((InternalEObject)newRoot).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - FeatureModelPackage.FEATURE_MODEL__ROOT, null, msgs);
-            msgs = basicSetRoot(newRoot, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__ROOT, newRoot, newRoot));
-    }
+		if (newRoot != root) {
+			NotificationChain msgs = null;
+			if (root != null)
+				msgs = ((InternalEObject)root).eInverseRemove(this, EOPPOSITE_FEATURE_BASE - FeatureModelPackage.FEATURE_MODEL__ROOT, null, msgs);
+			if (newRoot != null)
+				msgs = ((InternalEObject)newRoot).eInverseAdd(this, EOPPOSITE_FEATURE_BASE - FeatureModelPackage.FEATURE_MODEL__ROOT, null, msgs);
+			msgs = basicSetRoot(newRoot, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.FEATURE_MODEL__ROOT, newRoot, newRoot));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EList<Feature> getOrphans() {
-        if (orphans == null) {
-            orphans = new EObjectContainmentEList<Feature>(Feature.class, this, FeatureModelPackage.FEATURE_MODEL__ORPHANS);
-        }
-        return orphans;
-    }
+		if (orphans == null) {
+			orphans = new EObjectContainmentEList<Feature>(Feature.class, this, FeatureModelPackage.FEATURE_MODEL__ORPHANS);
+		}
+		return orphans;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EList<Constraint> getConstraints() {
-        if (constraints == null) {
-            constraints = new EObjectContainmentEList<Constraint>(Constraint.class, this, FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS);
-        }
-        return constraints;
-    }
+		if (constraints == null) {
+			constraints = new EObjectContainmentEList<Constraint>(Constraint.class, this, FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS);
+		}
+		return constraints;
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -341,164 +341,164 @@ public class FeatureModelImpl extends EObjectImpl implements FeatureModel {
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE_MODEL__ROOT:
-                return basicSetRoot(null, msgs);
-            case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
-                return ((InternalEList<?>)getOrphans()).basicRemove(otherEnd, msgs);
-            case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
-                return ((InternalEList<?>)getConstraints()).basicRemove(otherEnd, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE_MODEL__ROOT:
+				return basicSetRoot(null, msgs);
+			case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
+				return ((InternalEList<?>)getOrphans()).basicRemove(otherEnd, msgs);
+			case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
+				return ((InternalEList<?>)getConstraints()).basicRemove(otherEnd, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE_MODEL__NAME:
-                return getName();
-            case FeatureModelPackage.FEATURE_MODEL__VERSION:
-                return getVersion();
-            case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
-                return getDescription();
-            case FeatureModelPackage.FEATURE_MODEL__COMMENT:
-                return getComment();
-            case FeatureModelPackage.FEATURE_MODEL__ROOT:
-                return getRoot();
-            case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
-                return getOrphans();
-            case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
-                return getConstraints();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE_MODEL__NAME:
+				return getName();
+			case FeatureModelPackage.FEATURE_MODEL__VERSION:
+				return getVersion();
+			case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
+				return getDescription();
+			case FeatureModelPackage.FEATURE_MODEL__COMMENT:
+				return getComment();
+			case FeatureModelPackage.FEATURE_MODEL__ROOT:
+				return getRoot();
+			case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
+				return getOrphans();
+			case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
+				return getConstraints();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @SuppressWarnings("unchecked")
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE_MODEL__NAME:
-                setName((String)newValue);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__VERSION:
-                setVersion((String)newValue);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
-                setDescription((String)newValue);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__COMMENT:
-                setComment((String)newValue);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__ROOT:
-                setRoot((Feature)newValue);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
-                getOrphans().clear();
-                getOrphans().addAll((Collection<? extends Feature>)newValue);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
-                getConstraints().clear();
-                getConstraints().addAll((Collection<? extends Constraint>)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE_MODEL__NAME:
+				setName((String)newValue);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__VERSION:
+				setVersion((String)newValue);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
+				setDescription((String)newValue);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__COMMENT:
+				setComment((String)newValue);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__ROOT:
+				setRoot((Feature)newValue);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
+				getOrphans().clear();
+				getOrphans().addAll((Collection<? extends Feature>)newValue);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
+				getConstraints().clear();
+				getConstraints().addAll((Collection<? extends Constraint>)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE_MODEL__NAME:
-                setName(NAME_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__VERSION:
-                setVersion(VERSION_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
-                setDescription(DESCRIPTION_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__COMMENT:
-                setComment(COMMENT_EDEFAULT);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__ROOT:
-                setRoot((Feature)null);
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
-                getOrphans().clear();
-                return;
-            case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
-                getConstraints().clear();
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE_MODEL__NAME:
+				setName(NAME_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__VERSION:
+				setVersion(VERSION_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
+				setDescription(DESCRIPTION_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__COMMENT:
+				setComment(COMMENT_EDEFAULT);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__ROOT:
+				setRoot((Feature)null);
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
+				getOrphans().clear();
+				return;
+			case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
+				getConstraints().clear();
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.FEATURE_MODEL__NAME:
-                return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
-            case FeatureModelPackage.FEATURE_MODEL__VERSION:
-                return VERSION_EDEFAULT == null ? version != null : !VERSION_EDEFAULT.equals(version);
-            case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
-                return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
-            case FeatureModelPackage.FEATURE_MODEL__COMMENT:
-                return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
-            case FeatureModelPackage.FEATURE_MODEL__ROOT:
-                return root != null;
-            case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
-                return orphans != null && !orphans.isEmpty();
-            case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
-                return constraints != null && !constraints.isEmpty();
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.FEATURE_MODEL__NAME:
+				return NAME_EDEFAULT == null ? name != null : !NAME_EDEFAULT.equals(name);
+			case FeatureModelPackage.FEATURE_MODEL__VERSION:
+				return VERSION_EDEFAULT == null ? version != null : !VERSION_EDEFAULT.equals(version);
+			case FeatureModelPackage.FEATURE_MODEL__DESCRIPTION:
+				return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
+			case FeatureModelPackage.FEATURE_MODEL__COMMENT:
+				return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
+			case FeatureModelPackage.FEATURE_MODEL__ROOT:
+				return root != null;
+			case FeatureModelPackage.FEATURE_MODEL__ORPHANS:
+				return orphans != null && !orphans.isEmpty();
+			case FeatureModelPackage.FEATURE_MODEL__CONSTRAINTS:
+				return constraints != null && !constraints.isEmpty();
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (name: ");
-        result.append(name);
-        result.append(", version: ");
-        result.append(version);
-        result.append(", description: ");
-        result.append(description);
-        result.append(", comment: ");
-        result.append(comment);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (name: ");
+		result.append(name);
+		result.append(", version: ");
+		result.append(version);
+		result.append(", description: ");
+		result.append(description);
+		result.append(", comment: ");
+		result.append(comment);
+		result.append(')');
+		return result.toString();
+	}
 
 } //FeatureModelImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/FeatureModelPackageImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/FeatureModelPackageImpl.java
@@ -33,749 +33,760 @@ import org.eclipse.emf.ecore.impl.EPackageImpl;
  */
 public class FeatureModelPackageImpl extends EPackageImpl implements FeatureModelPackage {
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass featureModelEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass featureEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass groupEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass attributeEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EClass constraintEClass = null;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private EEnum attributeTypeEEnum = null;
 
     /**
-     * Creates an instance of the model <b>Package</b>, registered with
-     * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-     * package URI value.
-     * <p>Note: the correct way to create the package is via the static
-     * factory method {@link #init init()}, which also performs
-     * initialization of the package, or returns the registered package,
-     * if one already exists.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the model <b>Package</b>, registered with
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
+	 * package URI value.
+	 * <p>Note: the correct way to create the package is via the static
+	 * factory method {@link #init init()}, which also performs
+	 * initialization of the package, or returns the registered package,
+	 * if one already exists.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see org.eclipse.emf.ecore.EPackage.Registry
-     * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#eNS_URI
-     * @see #init()
-     * @generated
-     */
+	 * @see org.eclipse.emf.ecore.EPackage.Registry
+	 * @see cz.zcu.yafmt.model.fm.FeatureModelPackage#eNS_URI
+	 * @see #init()
+	 * @generated
+	 */
     private FeatureModelPackageImpl() {
-        super(eNS_URI, FeatureModelFactory.eINSTANCE);
-    }
+		super(eNS_URI, FeatureModelFactory.eINSTANCE);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private static boolean isInited = false;
 
     /**
-     * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
-     * 
-     * <p>This method is used to initialize {@link FeatureModelPackage#eINSTANCE} when that field is accessed.
-     * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-     * <!-- begin-user-doc -->
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * 
+	 * <p>This method is used to initialize {@link FeatureModelPackage#eINSTANCE} when that field is accessed.
+	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #eNS_URI
-     * @see #createPackageContents()
-     * @see #initializePackageContents()
-     * @generated
-     */
+	 * @see #eNS_URI
+	 * @see #createPackageContents()
+	 * @see #initializePackageContents()
+	 * @generated
+	 */
     public static FeatureModelPackage init() {
-        if (isInited) return (FeatureModelPackage)EPackage.Registry.INSTANCE.getEPackage(FeatureModelPackage.eNS_URI);
+		if (isInited) return (FeatureModelPackage)EPackage.Registry.INSTANCE.getEPackage(FeatureModelPackage.eNS_URI);
 
-        // Obtain or create and register package
-        FeatureModelPackageImpl theFeatureModelPackage = (FeatureModelPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof FeatureModelPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new FeatureModelPackageImpl());
+		// Obtain or create and register package
+		FeatureModelPackageImpl theFeatureModelPackage = (FeatureModelPackageImpl)(EPackage.Registry.INSTANCE.get(eNS_URI) instanceof FeatureModelPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI) : new FeatureModelPackageImpl());
 
-        isInited = true;
+		isInited = true;
 
-        // Obtain or create and register interdependencies
-        FeatureConfigurationPackageImpl theFeatureConfigurationPackage = (FeatureConfigurationPackageImpl)(EPackage.Registry.INSTANCE.getEPackage(FeatureConfigurationPackage.eNS_URI) instanceof FeatureConfigurationPackageImpl ? EPackage.Registry.INSTANCE.getEPackage(FeatureConfigurationPackage.eNS_URI) : FeatureConfigurationPackage.eINSTANCE);
+		// Obtain or create and register interdependencies
+		FeatureConfigurationPackageImpl theFeatureConfigurationPackage = (FeatureConfigurationPackageImpl)(EPackage.Registry.INSTANCE.getEPackage(FeatureConfigurationPackage.eNS_URI) instanceof FeatureConfigurationPackageImpl ? EPackage.Registry.INSTANCE.getEPackage(FeatureConfigurationPackage.eNS_URI) : FeatureConfigurationPackage.eINSTANCE);
 
-        // Create package meta-data objects
-        theFeatureModelPackage.createPackageContents();
-        theFeatureConfigurationPackage.createPackageContents();
+		// Create package meta-data objects
+		theFeatureModelPackage.createPackageContents();
+		theFeatureConfigurationPackage.createPackageContents();
 
-        // Initialize created meta-data
-        theFeatureModelPackage.initializePackageContents();
-        theFeatureConfigurationPackage.initializePackageContents();
+		// Initialize created meta-data
+		theFeatureModelPackage.initializePackageContents();
+		theFeatureConfigurationPackage.initializePackageContents();
 
-        // Mark meta-data to indicate it can't be changed
-        theFeatureModelPackage.freeze();
+		// Mark meta-data to indicate it can't be changed
+		theFeatureModelPackage.freeze();
 
   
-        // Update the registry and return the package
-        EPackage.Registry.INSTANCE.put(FeatureModelPackage.eNS_URI, theFeatureModelPackage);
-        return theFeatureModelPackage;
-    }
+		// Update the registry and return the package
+		EPackage.Registry.INSTANCE.put(FeatureModelPackage.eNS_URI, theFeatureModelPackage);
+		return theFeatureModelPackage;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getFeatureModel() {
-        return featureModelEClass;
-    }
+		return featureModelEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeatureModel_Name() {
-        return (EAttribute)featureModelEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)featureModelEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeatureModel_Description() {
-        return (EAttribute)featureModelEClass.getEStructuralFeatures().get(2);
-    }
+		return (EAttribute)featureModelEClass.getEStructuralFeatures().get(2);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeatureModel_Comment() {
-        return (EAttribute)featureModelEClass.getEStructuralFeatures().get(3);
-    }
+		return (EAttribute)featureModelEClass.getEStructuralFeatures().get(3);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeatureModel_Version() {
-        return (EAttribute)featureModelEClass.getEStructuralFeatures().get(1);
-    }
+		return (EAttribute)featureModelEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeatureModel_Root() {
-        return (EReference)featureModelEClass.getEStructuralFeatures().get(4);
-    }
+		return (EReference)featureModelEClass.getEStructuralFeatures().get(4);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeatureModel_Orphans() {
-        return (EReference)featureModelEClass.getEStructuralFeatures().get(5);
-    }
+		return (EReference)featureModelEClass.getEStructuralFeatures().get(5);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeatureModel_Constraints() {
-        return (EReference)featureModelEClass.getEStructuralFeatures().get(6);
-    }
+		return (EReference)featureModelEClass.getEStructuralFeatures().get(6);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getFeature() {
-        return featureEClass;
-    }
+		return featureEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Id() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Name() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(1);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Description() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(2);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(2);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Comment() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(3);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(3);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Lower() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(4);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(4);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Upper() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(5);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(5);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Root() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(6);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(6);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Orphan() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(7);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(7);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Optional() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(8);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(8);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Mandatory() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(9);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(9);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getFeature_Cloneable() {
-        return (EAttribute)featureEClass.getEStructuralFeatures().get(10);
-    }
+		return (EAttribute)featureEClass.getEStructuralFeatures().get(10);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeature_Attributes() {
-        return (EReference)featureEClass.getEStructuralFeatures().get(14);
-    }
+		return (EReference)featureEClass.getEStructuralFeatures().get(14);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeature_Parent() {
-        return (EReference)featureEClass.getEStructuralFeatures().get(11);
-    }
+		return (EReference)featureEClass.getEStructuralFeatures().get(11);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeature_ParentFeature() {
-        return (EReference)featureEClass.getEStructuralFeatures().get(12);
-    }
+		return (EReference)featureEClass.getEStructuralFeatures().get(12);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeature_ParentGroup() {
-        return (EReference)featureEClass.getEStructuralFeatures().get(13);
-    }
+		return (EReference)featureEClass.getEStructuralFeatures().get(13);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeature_Features() {
-        return (EReference)featureEClass.getEStructuralFeatures().get(15);
-    }
+		return (EReference)featureEClass.getEStructuralFeatures().get(15);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeature_Groups() {
-        return (EReference)featureEClass.getEStructuralFeatures().get(16);
-    }
+		return (EReference)featureEClass.getEStructuralFeatures().get(16);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getFeature_FeatureModel() {
-        return (EReference)featureEClass.getEStructuralFeatures().get(17);
-    }
+		return (EReference)featureEClass.getEStructuralFeatures().get(17);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getGroup() {
-        return groupEClass;
-    }
+		return groupEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getGroup_Lower() {
-        return (EAttribute)groupEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)groupEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getGroup_Upper() {
-        return (EAttribute)groupEClass.getEStructuralFeatures().get(1);
-    }
+		return (EAttribute)groupEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getGroup_Description() {
-        return (EAttribute)groupEClass.getEStructuralFeatures().get(2);
-    }
+		return (EAttribute)groupEClass.getEStructuralFeatures().get(2);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getGroup_Comment() {
-        return (EAttribute)groupEClass.getEStructuralFeatures().get(3);
-    }
+		return (EAttribute)groupEClass.getEStructuralFeatures().get(3);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getGroup_Xor() {
-        return (EAttribute)groupEClass.getEStructuralFeatures().get(4);
-    }
+		return (EAttribute)groupEClass.getEStructuralFeatures().get(4);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getGroup_Or() {
-        return (EAttribute)groupEClass.getEStructuralFeatures().get(5);
-    }
+		return (EAttribute)groupEClass.getEStructuralFeatures().get(5);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getGroup_Parent() {
-        return (EReference)groupEClass.getEStructuralFeatures().get(6);
-    }
+		return (EReference)groupEClass.getEStructuralFeatures().get(6);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getGroup_Features() {
-        return (EReference)groupEClass.getEStructuralFeatures().get(7);
-    }
+		return (EReference)groupEClass.getEStructuralFeatures().get(7);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getAttribute() {
-        return attributeEClass;
-    }
+		return attributeEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getAttribute_Id() {
-        return (EAttribute)attributeEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)attributeEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getAttribute_Name() {
-        return (EAttribute)attributeEClass.getEStructuralFeatures().get(1);
-    }
+		return (EAttribute)attributeEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getAttribute_Description() {
-        return (EAttribute)attributeEClass.getEStructuralFeatures().get(3);
-    }
+		return (EAttribute)attributeEClass.getEStructuralFeatures().get(4);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getAttribute_Comment() {
-        return (EAttribute)attributeEClass.getEStructuralFeatures().get(4);
-    }
+		return (EAttribute)attributeEClass.getEStructuralFeatures().get(5);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getAttribute_Feature() {
-        return (EReference)attributeEClass.getEStructuralFeatures().get(5);
-    }
+		return (EReference)attributeEClass.getEStructuralFeatures().get(6);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getAttribute_Type() {
-        return (EAttribute)attributeEClass.getEStructuralFeatures().get(2);
-    }
+		return (EAttribute)attributeEClass.getEStructuralFeatures().get(2);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getAttribute_Value() {
+		return (EAttribute)attributeEClass.getEStructuralFeatures().get(3);
+	}
+
+				/**
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EClass getConstraint() {
-        return constraintEClass;
-    }
+		return constraintEClass;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getConstraint_Value() {
-        return (EAttribute)constraintEClass.getEStructuralFeatures().get(0);
-    }
+		return (EAttribute)constraintEClass.getEStructuralFeatures().get(0);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getConstraint_Language() {
-        return (EAttribute)constraintEClass.getEStructuralFeatures().get(1);
-    }
+		return (EAttribute)constraintEClass.getEStructuralFeatures().get(1);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getConstraint_Description() {
-        return (EAttribute)constraintEClass.getEStructuralFeatures().get(2);
-    }
+		return (EAttribute)constraintEClass.getEStructuralFeatures().get(2);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EAttribute getConstraint_Comment() {
-        return (EAttribute)constraintEClass.getEStructuralFeatures().get(3);
-    }
+		return (EAttribute)constraintEClass.getEStructuralFeatures().get(3);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EReference getConstraint_FeatureModel() {
-        return (EReference)constraintEClass.getEStructuralFeatures().get(4);
-    }
+		return (EReference)constraintEClass.getEStructuralFeatures().get(4);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EEnum getAttributeType() {
-        return attributeTypeEEnum;
-    }
+		return attributeTypeEEnum;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModelFactory getFeatureModelFactory() {
-        return (FeatureModelFactory)getEFactoryInstance();
-    }
+		return (FeatureModelFactory)getEFactoryInstance();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private boolean isCreated = false;
 
     /**
-     * Creates the meta-model objects for the package.  This method is
-     * guarded to have no affect on any invocation but its first.
-     * <!-- begin-user-doc -->
+	 * Creates the meta-model objects for the package.  This method is
+	 * guarded to have no affect on any invocation but its first.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void createPackageContents() {
-        if (isCreated) return;
-        isCreated = true;
+		if (isCreated) return;
+		isCreated = true;
 
-        // Create classes and their features
-        featureModelEClass = createEClass(FEATURE_MODEL);
-        createEAttribute(featureModelEClass, FEATURE_MODEL__NAME);
-        createEAttribute(featureModelEClass, FEATURE_MODEL__VERSION);
-        createEAttribute(featureModelEClass, FEATURE_MODEL__DESCRIPTION);
-        createEAttribute(featureModelEClass, FEATURE_MODEL__COMMENT);
-        createEReference(featureModelEClass, FEATURE_MODEL__ROOT);
-        createEReference(featureModelEClass, FEATURE_MODEL__ORPHANS);
-        createEReference(featureModelEClass, FEATURE_MODEL__CONSTRAINTS);
+		// Create classes and their features
+		featureModelEClass = createEClass(FEATURE_MODEL);
+		createEAttribute(featureModelEClass, FEATURE_MODEL__NAME);
+		createEAttribute(featureModelEClass, FEATURE_MODEL__VERSION);
+		createEAttribute(featureModelEClass, FEATURE_MODEL__DESCRIPTION);
+		createEAttribute(featureModelEClass, FEATURE_MODEL__COMMENT);
+		createEReference(featureModelEClass, FEATURE_MODEL__ROOT);
+		createEReference(featureModelEClass, FEATURE_MODEL__ORPHANS);
+		createEReference(featureModelEClass, FEATURE_MODEL__CONSTRAINTS);
 
-        featureEClass = createEClass(FEATURE);
-        createEAttribute(featureEClass, FEATURE__ID);
-        createEAttribute(featureEClass, FEATURE__NAME);
-        createEAttribute(featureEClass, FEATURE__DESCRIPTION);
-        createEAttribute(featureEClass, FEATURE__COMMENT);
-        createEAttribute(featureEClass, FEATURE__LOWER);
-        createEAttribute(featureEClass, FEATURE__UPPER);
-        createEAttribute(featureEClass, FEATURE__ROOT);
-        createEAttribute(featureEClass, FEATURE__ORPHAN);
-        createEAttribute(featureEClass, FEATURE__OPTIONAL);
-        createEAttribute(featureEClass, FEATURE__MANDATORY);
-        createEAttribute(featureEClass, FEATURE__CLONEABLE);
-        createEReference(featureEClass, FEATURE__PARENT);
-        createEReference(featureEClass, FEATURE__PARENT_FEATURE);
-        createEReference(featureEClass, FEATURE__PARENT_GROUP);
-        createEReference(featureEClass, FEATURE__ATTRIBUTES);
-        createEReference(featureEClass, FEATURE__FEATURES);
-        createEReference(featureEClass, FEATURE__GROUPS);
-        createEReference(featureEClass, FEATURE__FEATURE_MODEL);
+		featureEClass = createEClass(FEATURE);
+		createEAttribute(featureEClass, FEATURE__ID);
+		createEAttribute(featureEClass, FEATURE__NAME);
+		createEAttribute(featureEClass, FEATURE__DESCRIPTION);
+		createEAttribute(featureEClass, FEATURE__COMMENT);
+		createEAttribute(featureEClass, FEATURE__LOWER);
+		createEAttribute(featureEClass, FEATURE__UPPER);
+		createEAttribute(featureEClass, FEATURE__ROOT);
+		createEAttribute(featureEClass, FEATURE__ORPHAN);
+		createEAttribute(featureEClass, FEATURE__OPTIONAL);
+		createEAttribute(featureEClass, FEATURE__MANDATORY);
+		createEAttribute(featureEClass, FEATURE__CLONEABLE);
+		createEReference(featureEClass, FEATURE__PARENT);
+		createEReference(featureEClass, FEATURE__PARENT_FEATURE);
+		createEReference(featureEClass, FEATURE__PARENT_GROUP);
+		createEReference(featureEClass, FEATURE__ATTRIBUTES);
+		createEReference(featureEClass, FEATURE__FEATURES);
+		createEReference(featureEClass, FEATURE__GROUPS);
+		createEReference(featureEClass, FEATURE__FEATURE_MODEL);
 
-        groupEClass = createEClass(GROUP);
-        createEAttribute(groupEClass, GROUP__LOWER);
-        createEAttribute(groupEClass, GROUP__UPPER);
-        createEAttribute(groupEClass, GROUP__DESCRIPTION);
-        createEAttribute(groupEClass, GROUP__COMMENT);
-        createEAttribute(groupEClass, GROUP__XOR);
-        createEAttribute(groupEClass, GROUP__OR);
-        createEReference(groupEClass, GROUP__PARENT);
-        createEReference(groupEClass, GROUP__FEATURES);
+		groupEClass = createEClass(GROUP);
+		createEAttribute(groupEClass, GROUP__LOWER);
+		createEAttribute(groupEClass, GROUP__UPPER);
+		createEAttribute(groupEClass, GROUP__DESCRIPTION);
+		createEAttribute(groupEClass, GROUP__COMMENT);
+		createEAttribute(groupEClass, GROUP__XOR);
+		createEAttribute(groupEClass, GROUP__OR);
+		createEReference(groupEClass, GROUP__PARENT);
+		createEReference(groupEClass, GROUP__FEATURES);
 
-        attributeEClass = createEClass(ATTRIBUTE);
-        createEAttribute(attributeEClass, ATTRIBUTE__ID);
-        createEAttribute(attributeEClass, ATTRIBUTE__NAME);
-        createEAttribute(attributeEClass, ATTRIBUTE__TYPE);
-        createEAttribute(attributeEClass, ATTRIBUTE__DESCRIPTION);
-        createEAttribute(attributeEClass, ATTRIBUTE__COMMENT);
-        createEReference(attributeEClass, ATTRIBUTE__FEATURE);
+		attributeEClass = createEClass(ATTRIBUTE);
+		createEAttribute(attributeEClass, ATTRIBUTE__ID);
+		createEAttribute(attributeEClass, ATTRIBUTE__NAME);
+		createEAttribute(attributeEClass, ATTRIBUTE__TYPE);
+		createEAttribute(attributeEClass, ATTRIBUTE__VALUE);
+		createEAttribute(attributeEClass, ATTRIBUTE__DESCRIPTION);
+		createEAttribute(attributeEClass, ATTRIBUTE__COMMENT);
+		createEReference(attributeEClass, ATTRIBUTE__FEATURE);
 
-        constraintEClass = createEClass(CONSTRAINT);
-        createEAttribute(constraintEClass, CONSTRAINT__VALUE);
-        createEAttribute(constraintEClass, CONSTRAINT__LANGUAGE);
-        createEAttribute(constraintEClass, CONSTRAINT__DESCRIPTION);
-        createEAttribute(constraintEClass, CONSTRAINT__COMMENT);
-        createEReference(constraintEClass, CONSTRAINT__FEATURE_MODEL);
+		constraintEClass = createEClass(CONSTRAINT);
+		createEAttribute(constraintEClass, CONSTRAINT__VALUE);
+		createEAttribute(constraintEClass, CONSTRAINT__LANGUAGE);
+		createEAttribute(constraintEClass, CONSTRAINT__DESCRIPTION);
+		createEAttribute(constraintEClass, CONSTRAINT__COMMENT);
+		createEReference(constraintEClass, CONSTRAINT__FEATURE_MODEL);
 
-        // Create enums
-        attributeTypeEEnum = createEEnum(ATTRIBUTE_TYPE);
-    }
+		// Create enums
+		attributeTypeEEnum = createEEnum(ATTRIBUTE_TYPE);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     private boolean isInitialized = false;
 
     /**
-     * Complete the initialization of the package and its meta-model.  This
-     * method is guarded to have no affect on any invocation but its first.
-     * <!-- begin-user-doc -->
+	 * Complete the initialization of the package and its meta-model.  This
+	 * method is guarded to have no affect on any invocation but its first.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void initializePackageContents() {
-        if (isInitialized) return;
-        isInitialized = true;
+		if (isInitialized) return;
+		isInitialized = true;
 
-        // Initialize package
-        setName(eNAME);
-        setNsPrefix(eNS_PREFIX);
-        setNsURI(eNS_URI);
+		// Initialize package
+		setName(eNAME);
+		setNsPrefix(eNS_PREFIX);
+		setNsURI(eNS_URI);
 
-        // Create type parameters
+		// Create type parameters
 
-        // Set bounds for type parameters
+		// Set bounds for type parameters
 
-        // Add supertypes to classes
+		// Add supertypes to classes
 
-        // Initialize classes and features; add operations and parameters
-        initEClass(featureModelEClass, FeatureModel.class, "FeatureModel", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getFeatureModel_Name(), ecorePackage.getEString(), "name", null, 1, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeatureModel_Version(), ecorePackage.getEString(), "version", null, 0, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeatureModel_Description(), ecorePackage.getEString(), "description", null, 0, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeatureModel_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeatureModel_Root(), this.getFeature(), null, "root", null, 1, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeatureModel_Orphans(), this.getFeature(), null, "orphans", null, 0, -1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeatureModel_Constraints(), this.getConstraint(), null, "constraints", null, 0, -1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		// Initialize classes and features; add operations and parameters
+		initEClass(featureModelEClass, FeatureModel.class, "FeatureModel", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getFeatureModel_Name(), ecorePackage.getEString(), "name", null, 1, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeatureModel_Version(), ecorePackage.getEString(), "version", null, 0, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeatureModel_Description(), ecorePackage.getEString(), "description", null, 0, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeatureModel_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeatureModel_Root(), this.getFeature(), null, "root", null, 1, 1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeatureModel_Orphans(), this.getFeature(), null, "orphans", null, 0, -1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeatureModel_Constraints(), this.getConstraint(), null, "constraints", null, 0, -1, FeatureModel.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        EOperation op = addEOperation(featureModelEClass, null, "getFeaturesById", 0, 1, IS_UNIQUE, IS_ORDERED);
-        addEParameter(op, ecorePackage.getEString(), "id", 0, 1, IS_UNIQUE, IS_ORDERED);
-        EGenericType g1 = createEGenericType(ecorePackage.getEEList());
-        EGenericType g2 = createEGenericType(this.getFeature());
-        g1.getETypeArguments().add(g2);
-        initEOperation(op, g1);
+		EOperation op = addEOperation(featureModelEClass, null, "getFeaturesById", 0, 1, IS_UNIQUE, IS_ORDERED);
+		addEParameter(op, ecorePackage.getEString(), "id", 0, 1, IS_UNIQUE, IS_ORDERED);
+		EGenericType g1 = createEGenericType(ecorePackage.getEEList());
+		EGenericType g2 = createEGenericType(this.getFeature());
+		g1.getETypeArguments().add(g2);
+		initEOperation(op, g1);
 
-        initEClass(featureEClass, Feature.class, "Feature", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getFeature_Id(), ecorePackage.getEString(), "id", null, 1, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Name(), ecorePackage.getEString(), "name", null, 1, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Description(), ecorePackage.getEString(), "description", null, 0, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Lower(), ecorePackage.getEInt(), "lower", "0", 1, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Upper(), ecorePackage.getEInt(), "upper", "1", 1, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Root(), ecorePackage.getEBoolean(), "root", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Orphan(), ecorePackage.getEBoolean(), "orphan", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Optional(), ecorePackage.getEBoolean(), "optional", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Mandatory(), ecorePackage.getEBoolean(), "mandatory", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getFeature_Cloneable(), ecorePackage.getEBoolean(), "cloneable", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEReference(getFeature_Parent(), ecorePackage.getEObject(), null, "parent", null, 0, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEReference(getFeature_ParentFeature(), this.getFeature(), this.getFeature_Features(), "parentFeature", null, 0, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeature_ParentGroup(), this.getGroup(), this.getGroup_Features(), "parentGroup", null, 0, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeature_Attributes(), this.getAttribute(), this.getAttribute_Feature(), "attributes", null, 0, -1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeature_Features(), this.getFeature(), this.getFeature_ParentFeature(), "features", null, 0, -1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeature_Groups(), this.getGroup(), this.getGroup_Parent(), "groups", null, 0, -1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getFeature_FeatureModel(), this.getFeatureModel(), null, "featureModel", null, 0, 1, Feature.class, IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEClass(featureEClass, Feature.class, "Feature", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getFeature_Id(), ecorePackage.getEString(), "id", null, 1, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Name(), ecorePackage.getEString(), "name", null, 1, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Description(), ecorePackage.getEString(), "description", null, 0, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Lower(), ecorePackage.getEInt(), "lower", "0", 1, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Upper(), ecorePackage.getEInt(), "upper", "1", 1, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Root(), ecorePackage.getEBoolean(), "root", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Orphan(), ecorePackage.getEBoolean(), "orphan", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Optional(), ecorePackage.getEBoolean(), "optional", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Mandatory(), ecorePackage.getEBoolean(), "mandatory", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getFeature_Cloneable(), ecorePackage.getEBoolean(), "cloneable", null, 1, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEReference(getFeature_Parent(), ecorePackage.getEObject(), null, "parent", null, 0, 1, Feature.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEReference(getFeature_ParentFeature(), this.getFeature(), this.getFeature_Features(), "parentFeature", null, 0, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeature_ParentGroup(), this.getGroup(), this.getGroup_Features(), "parentGroup", null, 0, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeature_Attributes(), this.getAttribute(), this.getAttribute_Feature(), "attributes", null, 0, -1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeature_Features(), this.getFeature(), this.getFeature_ParentFeature(), "features", null, 0, -1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeature_Groups(), this.getGroup(), this.getGroup_Parent(), "groups", null, 0, -1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getFeature_FeatureModel(), this.getFeatureModel(), null, "featureModel", null, 0, 1, Feature.class, IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 
-        initEClass(groupEClass, Group.class, "Group", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getGroup_Lower(), ecorePackage.getEInt(), "lower", "1", 1, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getGroup_Upper(), ecorePackage.getEInt(), "upper", "1", 1, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getGroup_Description(), ecorePackage.getEString(), "description", null, 0, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getGroup_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getGroup_Xor(), ecorePackage.getEBoolean(), "xor", null, 1, 1, Group.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEAttribute(getGroup_Or(), ecorePackage.getEBoolean(), "or", null, 1, 1, Group.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
-        initEReference(getGroup_Parent(), this.getFeature(), this.getFeature_Groups(), "parent", null, 1, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getGroup_Features(), this.getFeature(), this.getFeature_ParentGroup(), "features", null, 0, -1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(groupEClass, Group.class, "Group", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getGroup_Lower(), ecorePackage.getEInt(), "lower", "1", 1, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getGroup_Upper(), ecorePackage.getEInt(), "upper", "1", 1, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getGroup_Description(), ecorePackage.getEString(), "description", null, 0, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getGroup_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getGroup_Xor(), ecorePackage.getEBoolean(), "xor", null, 1, 1, Group.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEAttribute(getGroup_Or(), ecorePackage.getEBoolean(), "or", null, 1, 1, Group.class, IS_TRANSIENT, IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEReference(getGroup_Parent(), this.getFeature(), this.getFeature_Groups(), "parent", null, 1, 1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getGroup_Features(), this.getFeature(), this.getFeature_ParentGroup(), "features", null, 0, -1, Group.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(attributeEClass, Attribute.class, "Attribute", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getAttribute_Id(), ecorePackage.getEString(), "id", null, 1, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getAttribute_Name(), ecorePackage.getEString(), "name", null, 1, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getAttribute_Type(), this.getAttributeType(), "type", "BOOLEAN", 1, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getAttribute_Description(), ecorePackage.getEString(), "description", null, 0, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getAttribute_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getAttribute_Feature(), this.getFeature(), this.getFeature_Attributes(), "feature", null, 1, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEClass(attributeEClass, Attribute.class, "Attribute", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getAttribute_Id(), ecorePackage.getEString(), "id", null, 1, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getAttribute_Name(), ecorePackage.getEString(), "name", null, 1, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getAttribute_Type(), this.getAttributeType(), "type", "boolean", 1, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getAttribute_Value(), ecorePackage.getEString(), "value", null, 1, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getAttribute_Description(), ecorePackage.getEString(), "description", null, 0, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getAttribute_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getAttribute_Feature(), this.getFeature(), this.getFeature_Attributes(), "feature", null, 1, 1, Attribute.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-        initEClass(constraintEClass, Constraint.class, "Constraint", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-        initEAttribute(getConstraint_Value(), ecorePackage.getEString(), "value", null, 1, 1, Constraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getConstraint_Language(), ecorePackage.getEString(), "language", null, 1, 1, Constraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getConstraint_Description(), ecorePackage.getEString(), "description", null, 0, 1, Constraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEAttribute(getConstraint_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Constraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-        initEReference(getConstraint_FeatureModel(), this.getFeatureModel(), null, "featureModel", null, 0, 1, Constraint.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
+		initEClass(constraintEClass, Constraint.class, "Constraint", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getConstraint_Value(), ecorePackage.getEString(), "value", null, 1, 1, Constraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getConstraint_Language(), ecorePackage.getEString(), "language", null, 1, 1, Constraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getConstraint_Description(), ecorePackage.getEString(), "description", null, 0, 1, Constraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getConstraint_Comment(), ecorePackage.getEString(), "comment", null, 0, 1, Constraint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getConstraint_FeatureModel(), this.getFeatureModel(), null, "featureModel", null, 0, 1, Constraint.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 
-        // Initialize enums and add enum literals
-        initEEnum(attributeTypeEEnum, AttributeType.class, "AttributeType");
-        addEEnumLiteral(attributeTypeEEnum, AttributeType.BOOLEAN);
-        addEEnumLiteral(attributeTypeEEnum, AttributeType.INTEGER);
-        addEEnumLiteral(attributeTypeEEnum, AttributeType.DOUBLE);
-        addEEnumLiteral(attributeTypeEEnum, AttributeType.STRING);
+		// Initialize enums and add enum literals
+		initEEnum(attributeTypeEEnum, AttributeType.class, "AttributeType");
+		addEEnumLiteral(attributeTypeEEnum, AttributeType.BOOLEAN);
+		addEEnumLiteral(attributeTypeEEnum, AttributeType.INTEGER);
+		addEEnumLiteral(attributeTypeEEnum, AttributeType.DOUBLE);
+		addEEnumLiteral(attributeTypeEEnum, AttributeType.STRING);
 
-        // Create resource
-        createResource(eNS_URI);
-    }
+		// Create resource
+		createResource(eNS_URI);
+	}
 
 } //FeatureModelPackageImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/GroupImpl.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/impl/GroupImpl.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
+ * </p>
  * <ul>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.GroupImpl#getLower <em>Lower</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.GroupImpl#getUpper <em>Upper</em>}</li>
@@ -39,223 +40,222 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.GroupImpl#getParent <em>Parent</em>}</li>
  *   <li>{@link cz.zcu.yafmt.model.fm.impl.GroupImpl#getFeatures <em>Features</em>}</li>
  * </ul>
- * </p>
  *
  * @generated
  */
 public class GroupImpl extends EObjectImpl implements Group {
     /**
-     * The default value of the '{@link #getLower() <em>Lower</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getLower() <em>Lower</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getLower()
-     * @generated
-     * @ordered
-     */
+	 * @see #getLower()
+	 * @generated
+	 * @ordered
+	 */
     protected static final int LOWER_EDEFAULT = 1;
 
     /**
-     * The cached value of the '{@link #getLower() <em>Lower</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getLower() <em>Lower</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getLower()
-     * @generated
-     * @ordered
-     */
+	 * @see #getLower()
+	 * @generated
+	 * @ordered
+	 */
     protected int lower = LOWER_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getUpper() <em>Upper</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getUpper() <em>Upper</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getUpper()
-     * @generated
-     * @ordered
-     */
+	 * @see #getUpper()
+	 * @generated
+	 * @ordered
+	 */
     protected static final int UPPER_EDEFAULT = 1;
 
     /**
-     * The cached value of the '{@link #getUpper() <em>Upper</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getUpper() <em>Upper</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getUpper()
-     * @generated
-     * @ordered
-     */
+	 * @see #getUpper()
+	 * @generated
+	 * @ordered
+	 */
     protected int upper = UPPER_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String DESCRIPTION_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getDescription() <em>Description</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getDescription()
-     * @generated
-     * @ordered
-     */
+	 * @see #getDescription()
+	 * @generated
+	 * @ordered
+	 */
     protected String description = DESCRIPTION_EDEFAULT;
 
     /**
-     * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected static final String COMMENT_EDEFAULT = null;
 
     /**
-     * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getComment() <em>Comment</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getComment()
-     * @generated
-     * @ordered
-     */
+	 * @see #getComment()
+	 * @generated
+	 * @ordered
+	 */
     protected String comment = COMMENT_EDEFAULT;
 
     /**
-     * The default value of the '{@link #isXor() <em>Xor</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isXor() <em>Xor</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isXor()
-     * @generated
-     * @ordered
-     */
+	 * @see #isXor()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean XOR_EDEFAULT = false;
 
     /**
-     * The default value of the '{@link #isOr() <em>Or</em>}' attribute.
-     * <!-- begin-user-doc -->
+	 * The default value of the '{@link #isOr() <em>Or</em>}' attribute.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #isOr()
-     * @generated
-     * @ordered
-     */
+	 * @see #isOr()
+	 * @generated
+	 * @ordered
+	 */
     protected static final boolean OR_EDEFAULT = false;
 
     /**
-     * The cached value of the '{@link #getFeatures() <em>Features</em>}' containment reference list.
-     * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getFeatures() <em>Features</em>}' containment reference list.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @see #getFeatures()
-     * @generated
-     * @ordered
-     */
+	 * @see #getFeatures()
+	 * @generated
+	 * @ordered
+	 */
     protected EList<Feature> features;
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected GroupImpl() {
-        super();
-    }
+		super();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     protected EClass eStaticClass() {
-        return FeatureModelPackage.Literals.GROUP;
-    }
+		return FeatureModelPackage.Literals.GROUP;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public int getLower() {
-        return lower;
-    }
+		return lower;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setLower(int newLower) {
-        int oldLower = lower;
-        lower = newLower;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__LOWER, oldLower, lower));
-    }
+		int oldLower = lower;
+		lower = newLower;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__LOWER, oldLower, lower));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public int getUpper() {
-        return upper;
-    }
+		return upper;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setUpper(int newUpper) {
-        int oldUpper = upper;
-        upper = newUpper;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__UPPER, oldUpper, upper));
-    }
+		int oldUpper = upper;
+		upper = newUpper;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__UPPER, oldUpper, upper));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getDescription() {
-        return description;
-    }
+		return description;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setDescription(String newDescription) {
-        String oldDescription = description;
-        description = newDescription;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__DESCRIPTION, oldDescription, description));
-    }
+		String oldDescription = description;
+		description = newDescription;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__DESCRIPTION, oldDescription, description));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public String getComment() {
-        return comment;
-    }
+		return comment;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setComment(String newComment) {
-        String oldComment = comment;
-        comment = newComment;
-        if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__COMMENT, oldComment, comment));
-    }
+		String oldComment = comment;
+		comment = newComment;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__COMMENT, oldComment, comment));
+	}
 
     /**
      * <!-- begin-user-doc -->
@@ -313,257 +313,257 @@ public class GroupImpl extends EObjectImpl implements Group {
     }
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public Feature getParent() {
-        if (eContainerFeatureID() != FeatureModelPackage.GROUP__PARENT) return null;
-        return (Feature)eContainer();
-    }
+		if (eContainerFeatureID() != FeatureModelPackage.GROUP__PARENT) return null;
+		return (Feature)eInternalContainer();
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public NotificationChain basicSetParent(Feature newParent, NotificationChain msgs) {
-        msgs = eBasicSetContainer((InternalEObject)newParent, FeatureModelPackage.GROUP__PARENT, msgs);
-        return msgs;
-    }
+		msgs = eBasicSetContainer((InternalEObject)newParent, FeatureModelPackage.GROUP__PARENT, msgs);
+		return msgs;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public void setParent(Feature newParent) {
-        if (newParent != eInternalContainer() || (eContainerFeatureID() != FeatureModelPackage.GROUP__PARENT && newParent != null)) {
-            if (EcoreUtil.isAncestor(this, newParent))
-                throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
-            NotificationChain msgs = null;
-            if (eInternalContainer() != null)
-                msgs = eBasicRemoveFromContainer(msgs);
-            if (newParent != null)
-                msgs = ((InternalEObject)newParent).eInverseAdd(this, FeatureModelPackage.FEATURE__GROUPS, Feature.class, msgs);
-            msgs = basicSetParent(newParent, msgs);
-            if (msgs != null) msgs.dispatch();
-        }
-        else if (eNotificationRequired())
-            eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__PARENT, newParent, newParent));
-    }
+		if (newParent != eInternalContainer() || (eContainerFeatureID() != FeatureModelPackage.GROUP__PARENT && newParent != null)) {
+			if (EcoreUtil.isAncestor(this, newParent))
+				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
+			NotificationChain msgs = null;
+			if (eInternalContainer() != null)
+				msgs = eBasicRemoveFromContainer(msgs);
+			if (newParent != null)
+				msgs = ((InternalEObject)newParent).eInverseAdd(this, FeatureModelPackage.FEATURE__GROUPS, Feature.class, msgs);
+			msgs = basicSetParent(newParent, msgs);
+			if (msgs != null) msgs.dispatch();
+		}
+		else if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, FeatureModelPackage.GROUP__PARENT, newParent, newParent));
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public EList<Feature> getFeatures() {
-        if (features == null) {
-            features = new EObjectContainmentWithInverseEList<Feature>(Feature.class, this, FeatureModelPackage.GROUP__FEATURES, FeatureModelPackage.FEATURE__PARENT_GROUP);
-        }
-        return features;
-    }
+		if (features == null) {
+			features = new EObjectContainmentWithInverseEList<Feature>(Feature.class, this, FeatureModelPackage.GROUP__FEATURES, FeatureModelPackage.FEATURE__PARENT_GROUP);
+		}
+		return features;
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @SuppressWarnings("unchecked")
     @Override
     public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureModelPackage.GROUP__PARENT:
-                if (eInternalContainer() != null)
-                    msgs = eBasicRemoveFromContainer(msgs);
-                return basicSetParent((Feature)otherEnd, msgs);
-            case FeatureModelPackage.GROUP__FEATURES:
-                return ((InternalEList<InternalEObject>)(InternalEList<?>)getFeatures()).basicAdd(otherEnd, msgs);
-        }
-        return super.eInverseAdd(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.GROUP__PARENT:
+				if (eInternalContainer() != null)
+					msgs = eBasicRemoveFromContainer(msgs);
+				return basicSetParent((Feature)otherEnd, msgs);
+			case FeatureModelPackage.GROUP__FEATURES:
+				return ((InternalEList<InternalEObject>)(InternalEList<?>)getFeatures()).basicAdd(otherEnd, msgs);
+		}
+		return super.eInverseAdd(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
-        switch (featureID) {
-            case FeatureModelPackage.GROUP__PARENT:
-                return basicSetParent(null, msgs);
-            case FeatureModelPackage.GROUP__FEATURES:
-                return ((InternalEList<?>)getFeatures()).basicRemove(otherEnd, msgs);
-        }
-        return super.eInverseRemove(otherEnd, featureID, msgs);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.GROUP__PARENT:
+				return basicSetParent(null, msgs);
+			case FeatureModelPackage.GROUP__FEATURES:
+				return ((InternalEList<?>)getFeatures()).basicRemove(otherEnd, msgs);
+		}
+		return super.eInverseRemove(otherEnd, featureID, msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public NotificationChain eBasicRemoveFromContainerFeature(NotificationChain msgs) {
-        switch (eContainerFeatureID()) {
-            case FeatureModelPackage.GROUP__PARENT:
-                return eInternalContainer().eInverseRemove(this, FeatureModelPackage.FEATURE__GROUPS, Feature.class, msgs);
-        }
-        return super.eBasicRemoveFromContainerFeature(msgs);
-    }
+		switch (eContainerFeatureID()) {
+			case FeatureModelPackage.GROUP__PARENT:
+				return eInternalContainer().eInverseRemove(this, FeatureModelPackage.FEATURE__GROUPS, Feature.class, msgs);
+		}
+		return super.eBasicRemoveFromContainerFeature(msgs);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
-        switch (featureID) {
-            case FeatureModelPackage.GROUP__LOWER:
-                return getLower();
-            case FeatureModelPackage.GROUP__UPPER:
-                return getUpper();
-            case FeatureModelPackage.GROUP__DESCRIPTION:
-                return getDescription();
-            case FeatureModelPackage.GROUP__COMMENT:
-                return getComment();
-            case FeatureModelPackage.GROUP__XOR:
-                return isXor();
-            case FeatureModelPackage.GROUP__OR:
-                return isOr();
-            case FeatureModelPackage.GROUP__PARENT:
-                return getParent();
-            case FeatureModelPackage.GROUP__FEATURES:
-                return getFeatures();
-        }
-        return super.eGet(featureID, resolve, coreType);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.GROUP__LOWER:
+				return getLower();
+			case FeatureModelPackage.GROUP__UPPER:
+				return getUpper();
+			case FeatureModelPackage.GROUP__DESCRIPTION:
+				return getDescription();
+			case FeatureModelPackage.GROUP__COMMENT:
+				return getComment();
+			case FeatureModelPackage.GROUP__XOR:
+				return isXor();
+			case FeatureModelPackage.GROUP__OR:
+				return isOr();
+			case FeatureModelPackage.GROUP__PARENT:
+				return getParent();
+			case FeatureModelPackage.GROUP__FEATURES:
+				return getFeatures();
+		}
+		return super.eGet(featureID, resolve, coreType);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @SuppressWarnings("unchecked")
     @Override
     public void eSet(int featureID, Object newValue) {
-        switch (featureID) {
-            case FeatureModelPackage.GROUP__LOWER:
-                setLower((Integer)newValue);
-                return;
-            case FeatureModelPackage.GROUP__UPPER:
-                setUpper((Integer)newValue);
-                return;
-            case FeatureModelPackage.GROUP__DESCRIPTION:
-                setDescription((String)newValue);
-                return;
-            case FeatureModelPackage.GROUP__COMMENT:
-                setComment((String)newValue);
-                return;
-            case FeatureModelPackage.GROUP__XOR:
-                setXor((Boolean)newValue);
-                return;
-            case FeatureModelPackage.GROUP__OR:
-                setOr((Boolean)newValue);
-                return;
-            case FeatureModelPackage.GROUP__PARENT:
-                setParent((Feature)newValue);
-                return;
-            case FeatureModelPackage.GROUP__FEATURES:
-                getFeatures().clear();
-                getFeatures().addAll((Collection<? extends Feature>)newValue);
-                return;
-        }
-        super.eSet(featureID, newValue);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.GROUP__LOWER:
+				setLower((Integer)newValue);
+				return;
+			case FeatureModelPackage.GROUP__UPPER:
+				setUpper((Integer)newValue);
+				return;
+			case FeatureModelPackage.GROUP__DESCRIPTION:
+				setDescription((String)newValue);
+				return;
+			case FeatureModelPackage.GROUP__COMMENT:
+				setComment((String)newValue);
+				return;
+			case FeatureModelPackage.GROUP__XOR:
+				setXor((Boolean)newValue);
+				return;
+			case FeatureModelPackage.GROUP__OR:
+				setOr((Boolean)newValue);
+				return;
+			case FeatureModelPackage.GROUP__PARENT:
+				setParent((Feature)newValue);
+				return;
+			case FeatureModelPackage.GROUP__FEATURES:
+				getFeatures().clear();
+				getFeatures().addAll((Collection<? extends Feature>)newValue);
+				return;
+		}
+		super.eSet(featureID, newValue);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public void eUnset(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.GROUP__LOWER:
-                setLower(LOWER_EDEFAULT);
-                return;
-            case FeatureModelPackage.GROUP__UPPER:
-                setUpper(UPPER_EDEFAULT);
-                return;
-            case FeatureModelPackage.GROUP__DESCRIPTION:
-                setDescription(DESCRIPTION_EDEFAULT);
-                return;
-            case FeatureModelPackage.GROUP__COMMENT:
-                setComment(COMMENT_EDEFAULT);
-                return;
-            case FeatureModelPackage.GROUP__XOR:
-                setXor(XOR_EDEFAULT);
-                return;
-            case FeatureModelPackage.GROUP__OR:
-                setOr(OR_EDEFAULT);
-                return;
-            case FeatureModelPackage.GROUP__PARENT:
-                setParent((Feature)null);
-                return;
-            case FeatureModelPackage.GROUP__FEATURES:
-                getFeatures().clear();
-                return;
-        }
-        super.eUnset(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.GROUP__LOWER:
+				setLower(LOWER_EDEFAULT);
+				return;
+			case FeatureModelPackage.GROUP__UPPER:
+				setUpper(UPPER_EDEFAULT);
+				return;
+			case FeatureModelPackage.GROUP__DESCRIPTION:
+				setDescription(DESCRIPTION_EDEFAULT);
+				return;
+			case FeatureModelPackage.GROUP__COMMENT:
+				setComment(COMMENT_EDEFAULT);
+				return;
+			case FeatureModelPackage.GROUP__XOR:
+				setXor(XOR_EDEFAULT);
+				return;
+			case FeatureModelPackage.GROUP__OR:
+				setOr(OR_EDEFAULT);
+				return;
+			case FeatureModelPackage.GROUP__PARENT:
+				setParent((Feature)null);
+				return;
+			case FeatureModelPackage.GROUP__FEATURES:
+				getFeatures().clear();
+				return;
+		}
+		super.eUnset(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public boolean eIsSet(int featureID) {
-        switch (featureID) {
-            case FeatureModelPackage.GROUP__LOWER:
-                return lower != LOWER_EDEFAULT;
-            case FeatureModelPackage.GROUP__UPPER:
-                return upper != UPPER_EDEFAULT;
-            case FeatureModelPackage.GROUP__DESCRIPTION:
-                return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
-            case FeatureModelPackage.GROUP__COMMENT:
-                return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
-            case FeatureModelPackage.GROUP__XOR:
-                return isXor() != XOR_EDEFAULT;
-            case FeatureModelPackage.GROUP__OR:
-                return isOr() != OR_EDEFAULT;
-            case FeatureModelPackage.GROUP__PARENT:
-                return getParent() != null;
-            case FeatureModelPackage.GROUP__FEATURES:
-                return features != null && !features.isEmpty();
-        }
-        return super.eIsSet(featureID);
-    }
+		switch (featureID) {
+			case FeatureModelPackage.GROUP__LOWER:
+				return lower != LOWER_EDEFAULT;
+			case FeatureModelPackage.GROUP__UPPER:
+				return upper != UPPER_EDEFAULT;
+			case FeatureModelPackage.GROUP__DESCRIPTION:
+				return DESCRIPTION_EDEFAULT == null ? description != null : !DESCRIPTION_EDEFAULT.equals(description);
+			case FeatureModelPackage.GROUP__COMMENT:
+				return COMMENT_EDEFAULT == null ? comment != null : !COMMENT_EDEFAULT.equals(comment);
+			case FeatureModelPackage.GROUP__XOR:
+				return isXor() != XOR_EDEFAULT;
+			case FeatureModelPackage.GROUP__OR:
+				return isOr() != OR_EDEFAULT;
+			case FeatureModelPackage.GROUP__PARENT:
+				return getParent() != null;
+			case FeatureModelPackage.GROUP__FEATURES:
+				return features != null && !features.isEmpty();
+		}
+		return super.eIsSet(featureID);
+	}
 
     /**
-     * <!-- begin-user-doc -->
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     @Override
     public String toString() {
-        if (eIsProxy()) return super.toString();
+		if (eIsProxy()) return super.toString();
 
-        StringBuffer result = new StringBuffer(super.toString());
-        result.append(" (lower: ");
-        result.append(lower);
-        result.append(", upper: ");
-        result.append(upper);
-        result.append(", description: ");
-        result.append(description);
-        result.append(", comment: ");
-        result.append(comment);
-        result.append(')');
-        return result.toString();
-    }
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (lower: ");
+		result.append(lower);
+		result.append(", upper: ");
+		result.append(upper);
+		result.append(", description: ");
+		result.append(description);
+		result.append(", comment: ");
+		result.append(comment);
+		result.append(')');
+		return result.toString();
+	}
 
 } //GroupImpl

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/util/FeatureModelAdapterFactory.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/util/FeatureModelAdapterFactory.java
@@ -21,77 +21,77 @@ import org.eclipse.emf.ecore.EObject;
  */
 public class FeatureModelAdapterFactory extends AdapterFactoryImpl {
     /**
-     * The cached model package.
-     * <!-- begin-user-doc -->
+	 * The cached model package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected static FeatureModelPackage modelPackage;
 
     /**
-     * Creates an instance of the adapter factory.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the adapter factory.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModelAdapterFactory() {
-        if (modelPackage == null) {
-            modelPackage = FeatureModelPackage.eINSTANCE;
-        }
-    }
+		if (modelPackage == null) {
+			modelPackage = FeatureModelPackage.eINSTANCE;
+		}
+	}
 
     /**
-     * Returns whether this factory is applicable for the type of the object.
-     * <!-- begin-user-doc -->
+	 * Returns whether this factory is applicable for the type of the object.
+	 * <!-- begin-user-doc -->
      * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
      * <!-- end-user-doc -->
-     * @return whether this factory is applicable for the type of the object.
-     * @generated
-     */
+	 * @return whether this factory is applicable for the type of the object.
+	 * @generated
+	 */
     @Override
     public boolean isFactoryForType(Object object) {
-        if (object == modelPackage) {
-            return true;
-        }
-        if (object instanceof EObject) {
-            return ((EObject)object).eClass().getEPackage() == modelPackage;
-        }
-        return false;
-    }
+		if (object == modelPackage) {
+			return true;
+		}
+		if (object instanceof EObject) {
+			return ((EObject)object).eClass().getEPackage() == modelPackage;
+		}
+		return false;
+	}
 
     /**
-     * The switch that delegates to the <code>createXXX</code> methods.
-     * <!-- begin-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected FeatureModelSwitch<Adapter> modelSwitch =
         new FeatureModelSwitch<Adapter>() {
-            @Override
-            public Adapter caseFeatureModel(FeatureModel object) {
-                return createFeatureModelAdapter();
-            }
-            @Override
-            public Adapter caseFeature(Feature object) {
-                return createFeatureAdapter();
-            }
-            @Override
-            public Adapter caseGroup(Group object) {
-                return createGroupAdapter();
-            }
-            @Override
-            public Adapter caseAttribute(Attribute object) {
-                return createAttributeAdapter();
-            }
-            @Override
-            public Adapter caseConstraint(Constraint object) {
-                return createConstraintAdapter();
-            }
-            @Override
-            public Adapter defaultCase(EObject object) {
-                return createEObjectAdapter();
-            }
-        };
+			@Override
+			public Adapter caseFeatureModel(FeatureModel object) {
+				return createFeatureModelAdapter();
+			}
+			@Override
+			public Adapter caseFeature(Feature object) {
+				return createFeatureAdapter();
+			}
+			@Override
+			public Adapter caseGroup(Group object) {
+				return createGroupAdapter();
+			}
+			@Override
+			public Adapter caseAttribute(Attribute object) {
+				return createAttributeAdapter();
+			}
+			@Override
+			public Adapter caseConstraint(Constraint object) {
+				return createConstraintAdapter();
+			}
+			@Override
+			public Adapter defaultCase(EObject object) {
+				return createEObjectAdapter();
+			}
+		};
 
     /**
      * Creates an adapter for the <code>target</code>.
@@ -111,85 +111,85 @@ public class FeatureModelAdapterFactory extends AdapterFactoryImpl {
 
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.FeatureModel <em>Feature Model</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.FeatureModel <em>Feature Model</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fm.FeatureModel
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fm.FeatureModel
+	 * @generated
+	 */
     public Adapter createFeatureModelAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.Feature <em>Feature</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.Feature <em>Feature</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fm.Feature
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fm.Feature
+	 * @generated
+	 */
     public Adapter createFeatureAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.Group <em>Group</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.Group <em>Group</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fm.Group
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fm.Group
+	 * @generated
+	 */
     public Adapter createGroupAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.Attribute <em>Attribute</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.Attribute <em>Attribute</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fm.Attribute
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fm.Attribute
+	 * @generated
+	 */
     public Adapter createAttributeAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.Constraint <em>Constraint</em>}'.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for an object of class '{@link cz.zcu.yafmt.model.fm.Constraint <em>Constraint</em>}'.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null so that we can easily ignore cases;
      * it's useful to ignore a case when inheritance will catch all the cases anyway.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @see cz.zcu.yafmt.model.fm.Constraint
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @see cz.zcu.yafmt.model.fm.Constraint
+	 * @generated
+	 */
     public Adapter createConstraintAdapter() {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Creates a new adapter for the default case.
-     * <!-- begin-user-doc -->
+	 * Creates a new adapter for the default case.
+	 * <!-- begin-user-doc -->
      * This default implementation returns null.
      * <!-- end-user-doc -->
-     * @return the new adapter.
-     * @generated
-     */
+	 * @return the new adapter.
+	 * @generated
+	 */
     public Adapter createEObjectAdapter() {
-        return null;
-    }
+		return null;
+	}
 
 } //FeatureModelAdapterFactory

--- a/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/util/FeatureModelSwitch.java
+++ b/cz.zcu.yafmt.model/src/cz/zcu/yafmt/model/fm/util/FeatureModelSwitch.java
@@ -24,171 +24,171 @@ import org.eclipse.emf.ecore.util.Switch;
  */
 public class FeatureModelSwitch<T> extends Switch<T> {
     /**
-     * The cached model package
-     * <!-- begin-user-doc -->
+	 * The cached model package
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     protected static FeatureModelPackage modelPackage;
 
     /**
-     * Creates an instance of the switch.
-     * <!-- begin-user-doc -->
+	 * Creates an instance of the switch.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
-     */
+	 * @generated
+	 */
     public FeatureModelSwitch() {
-        if (modelPackage == null) {
-            modelPackage = FeatureModelPackage.eINSTANCE;
-        }
-    }
+		if (modelPackage == null) {
+			modelPackage = FeatureModelPackage.eINSTANCE;
+		}
+	}
 
     /**
-     * Checks whether this is a switch for the given package.
-     * <!-- begin-user-doc -->
+	 * Checks whether this is a switch for the given package.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @parameter ePackage the package in question.
-     * @return whether this is a switch for the given package.
-     * @generated
-     */
+	 * @param ePackage the package in question.
+	 * @return whether this is a switch for the given package.
+	 * @generated
+	 */
     @Override
     protected boolean isSwitchFor(EPackage ePackage) {
-        return ePackage == modelPackage;
-    }
+		return ePackage == modelPackage;
+	}
 
     /**
-     * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-     * <!-- begin-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
+	 * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @return the first non-null result returned by a <code>caseXXX</code> call.
-     * @generated
-     */
+	 * @return the first non-null result returned by a <code>caseXXX</code> call.
+	 * @generated
+	 */
     @Override
     protected T doSwitch(int classifierID, EObject theEObject) {
-        switch (classifierID) {
-            case FeatureModelPackage.FEATURE_MODEL: {
-                FeatureModel featureModel = (FeatureModel)theEObject;
-                T result = caseFeatureModel(featureModel);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureModelPackage.FEATURE: {
-                Feature feature = (Feature)theEObject;
-                T result = caseFeature(feature);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureModelPackage.GROUP: {
-                Group group = (Group)theEObject;
-                T result = caseGroup(group);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureModelPackage.ATTRIBUTE: {
-                Attribute attribute = (Attribute)theEObject;
-                T result = caseAttribute(attribute);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            case FeatureModelPackage.CONSTRAINT: {
-                Constraint constraint = (Constraint)theEObject;
-                T result = caseConstraint(constraint);
-                if (result == null) result = defaultCase(theEObject);
-                return result;
-            }
-            default: return defaultCase(theEObject);
-        }
-    }
+		switch (classifierID) {
+			case FeatureModelPackage.FEATURE_MODEL: {
+				FeatureModel featureModel = (FeatureModel)theEObject;
+				T result = caseFeatureModel(featureModel);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureModelPackage.FEATURE: {
+				Feature feature = (Feature)theEObject;
+				T result = caseFeature(feature);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureModelPackage.GROUP: {
+				Group group = (Group)theEObject;
+				T result = caseGroup(group);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureModelPackage.ATTRIBUTE: {
+				Attribute attribute = (Attribute)theEObject;
+				T result = caseAttribute(attribute);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			case FeatureModelPackage.CONSTRAINT: {
+				Constraint constraint = (Constraint)theEObject;
+				T result = caseConstraint(constraint);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
+			default: return defaultCase(theEObject);
+		}
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Feature Model</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Feature Model</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Feature Model</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Feature Model</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseFeatureModel(FeatureModel object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Feature</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Feature</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Feature</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Feature</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseFeature(Feature object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Group</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Group</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Group</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Group</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseGroup(Group object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Attribute</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Attribute</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Attribute</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Attribute</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseAttribute(Attribute object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>Constraint</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Constraint</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>Constraint</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>Constraint</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
     public T caseConstraint(Constraint object) {
-        return null;
-    }
+		return null;
+	}
 
     /**
-     * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-     * <!-- begin-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * <!-- begin-user-doc -->
      * This implementation returns null;
      * returning a non-null result will terminate the switch, but this is the last case anyway.
      * <!-- end-user-doc -->
-     * @param object the target of the switch.
-     * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
-     * @see #doSwitch(org.eclipse.emf.ecore.EObject)
-     * @generated
-     */
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
+	 * @generated
+	 */
     @Override
     public T defaultCase(EObject object) {
-        return null;
-    }
+		return null;
+	}
 
 } //FeatureModelSwitch

--- a/cz.zcu.yafmt.update/site.xml
+++ b/cz.zcu.yafmt.update/site.xml
@@ -15,16 +15,16 @@
    <feature url="features/org.eclipse.xtext.ui_2.4.1.v201304180855.jar" id="org.eclipse.xtext.ui" version="2.4.1.v201304180855">
       <category name="dependencies"/>
    </feature>
-   <feature url="features/cz.zcu.yafmt.clang.bcl.feature_0.3.0.201305112307.jar" id="cz.zcu.yafmt.clang.bcl.feature" version="0.3.0.201305112307">
+   <feature url="features/cz.zcu.yafmt.clang.bcl.feature_0.3.0.201509041124.jar" id="cz.zcu.yafmt.clang.bcl.feature" version="0.3.0.201509041124">
       <category name="yafmt"/>
    </feature>
-   <feature url="features/cz.zcu.yafmt.ui.editors.fc.feature_0.3.0.201305112307.jar" id="cz.zcu.yafmt.ui.editors.fc.feature" version="0.3.0.201305112307">
+   <feature url="features/cz.zcu.yafmt.ui.editors.fc.feature_0.3.0.201509041124.jar" id="cz.zcu.yafmt.ui.editors.fc.feature" version="0.3.0.201509041124">
       <category name="yafmt"/>
    </feature>
-   <feature url="features/cz.zcu.yafmt.ui.editors.fm.feature_0.3.0.201305112307.jar" id="cz.zcu.yafmt.ui.editors.fm.feature" version="0.3.0.201305112307">
+   <feature url="features/cz.zcu.yafmt.ui.editors.fm.feature_0.3.0.201509041124.jar" id="cz.zcu.yafmt.ui.editors.fm.feature" version="0.3.0.201509041124">
       <category name="yafmt"/>
    </feature>
-   <feature url="features/cz.zcu.yafmt.ui.views.fm.feature_0.3.0.201305112307.jar" id="cz.zcu.yafmt.ui.views.fm.feature" version="0.3.0.201305112307">
+   <feature url="features/cz.zcu.yafmt.ui.views.fm.feature_0.3.0.201509041124.jar" id="cz.zcu.yafmt.ui.views.fm.feature" version="0.3.0.201509041124">
       <category name="yafmt"/>
    </feature>
    <category-def name="yafmt" label="YAFMT">


### PR DESCRIPTION
WIP: added Value to Attribute and regenerated code
So in Model Editor (FM) the value can be defined and used in own code
generator as fallback if not AttributeValue was defined by user in
Feature Configuration (FC).

TODO:
- show the default value in FC
- add something like "use default value" checkbox in FC, if checked copy
the value from FM to FC and store that is was copied not entered. If not
checked then delete AttributeValue if was copied from FM before or just
empty the value inside AttributeValue... just thinking...

https://bitbucket.org/jpikl/yafmt/issues/1/add-support-of-default-attribute-values